### PR TITLE
Remove ACF Pro mention and update plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FreeFlexOverlay Builder
+# wp-overlay-restaurant
 
-FreeFlexOverlay Builder combines a small page builder with an overlay search. It ships a custom meta box powered by [CMB2](https://github.com/CMB2/CMB2) to create flexible fullwidth or grid modules on pages or posts. A simple JavaScript powered overlay search is included to search through a small data set which can be replaced with your own items.
+wp-overlay-restaurant combines a small page builder with an overlay search. It ships a custom meta box powered by [CMB2](https://github.com/CMB2/CMB2) to create flexible fullwidth or grid modules on pages or posts. A simple JavaScript powered overlay search is included to search through a small data set which can be replaced with your own items.
 
 ## Features
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -1,8 +1,8 @@
 <?php
 /*
-Plugin Name:       FreeFlexOverlay Builder
+Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
-Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche ohne ACF Pro.
+Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
 Version:           2.1.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/


### PR DESCRIPTION
## Summary
- rename plugin to match the GitHub repository name
- remove leftover ACF Pro reference in plugin description
- update README heading

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856af5eb55c8329b6bb5117180e0a47