### PR TITLE
Implement automatic CMB2 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 
 ## Requirements
 
-The plugin relies on the CMB2 library. Either install the "CMB2" plugin from WordPress.org or copy the library into `includes/cmb2/` so that `includes/cmb2/init.php` exists.
+The plugin relies on the CMB2 library. If CMB2 isn't available the builder tries
+to install the latest version automatically from WordPress.org. You can also
+install CMB2 manually or copy the library into `includes/cmb2/` so that
+`includes/cmb2/init.php` exists.
 
 ## Installation
 
 1. Upload the plugin folder to your WordPress installation and activate it.
-2. Ensure the CMB2 library is available (see **Requirements**).
+2. The plugin attempts to fetch CMB2 on activation. If that fails, install CMB2
+   manually (see **Requirements**).
 3. Create or edit a page/post and configure modules via the **Page Modules** meta box.
 4. Insert the shortcode `[free_flexio_modules]` into the content where the modules and search should appear.
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.1.0
+Version:           2.2.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -13,6 +13,48 @@ Text Domain:       freeflexoverlay
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Ensure the CMB2 plugin is installed and activated.
+ *
+ * Attempts to fetch the latest version from WordPress.org when missing.
+ */
+function ffo_maybe_install_cmb2() {
+    if ( defined( 'CMB2_LOADED' ) || class_exists( 'CMB2' ) ) {
+        return;
+    }
+
+    $bundled = plugin_dir_path( __FILE__ ) . 'includes/cmb2/init.php';
+    if ( file_exists( $bundled ) ) {
+        return;
+    }
+
+    include_once ABSPATH . 'wp-admin/includes/plugin.php';
+    include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+    include_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
+
+    $plugin = 'cmb2/init.php';
+
+    if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
+        if ( ! is_plugin_active( $plugin ) ) {
+            activate_plugin( $plugin );
+        }
+        return;
+    }
+
+    $api = plugins_api( 'plugin_information', [ 'slug' => 'cmb2', 'fields' => [ 'sections' => false ] ] );
+    if ( is_wp_error( $api ) ) {
+        return;
+    }
+
+    $upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
+    $result   = $upgrader->install( $api->download_link );
+    if ( ! is_wp_error( $result ) && file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
+        activate_plugin( $plugin );
+    }
+}
+register_activation_hook( __FILE__, 'ffo_maybe_install_cmb2' );
+add_action( 'admin_init', 'ffo_maybe_install_cmb2' );
 
 /**
  * Check if CMB2 is available and, if not, display an admin notice.
@@ -35,8 +77,8 @@ function ffo_check_cmb2_notice() {
     }
     echo '<div class="notice notice-warning"><p>' .
         esc_html__(
-            'FreeFlexOverlay Builder requires the CMB2 library. ' .
-            'Please install the CMB2 plugin or place it in the plugin\'s includes/cmb2 directory.',
+            'FreeFlexOverlay Builder requires the CMB2 library. The plugin attempts to install it automatically. ' .
+            'If this fails, please install the CMB2 plugin or place it in the plugin\'s includes/cmb2 directory.',
             'freeflexoverlay'
         ) .
         '</p></div>';
@@ -69,13 +111,13 @@ function ffo_enqueue_assets() {
         'freeflexoverlay-style',
         plugin_dir_url( __FILE__ ) . 'assets/style.css',
         [],
-        '2.1.0'
+        '2.2.0'
     );
     wp_enqueue_script(
         'freeflexoverlay-script',
         plugin_dir_url( __FILE__ ) . 'assets/script.js',
         [ 'jquery' ],
-        '2.1.0',
+        '2.2.0',
         true
     );
 }


### PR DESCRIPTION
## Summary
- auto install and activate the CMB2 plugin if missing
- explain new behaviour in the README
- bump plugin version

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b048d0948329a442e996f20eeebd