### PR TITLE
Fix shortcode fatal and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ install CMB2 manually or copy the library into `includes/cmb2/` so that
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. The plugin attempts to fetch CMB2 on activation. If that fails, install CMB2
    manually (see **Requirements**).
-3. Create or edit a page/post and configure modules via the **Page Modules** meta box.
-4. Insert the shortcode `[free_flexio_modules]` into the content where the modules and search should appear.
+3. Version 2.2.1 improves stability when the shortcode runs outside the main
+   query by checking that a valid post is available.
+4. Create or edit a page/post and configure modules via the **Page Modules** meta
+   box.
+5. Insert the shortcode `[free_flexio_modules]` into the content where the
+   modules and search should appear.
 
 ## Customising the search
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.2.0
+Version:           2.2.1
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -111,13 +111,13 @@ function ffo_enqueue_assets() {
         'freeflexoverlay-style',
         plugin_dir_url( __FILE__ ) . 'assets/style.css',
         [],
-        '2.2.0'
+        '2.2.1'
     );
     wp_enqueue_script(
         'freeflexoverlay-script',
         plugin_dir_url( __FILE__ ) . 'assets/script.js',
         [ 'jquery' ],
-        '2.2.0',
+        '2.2.1',
         true
     );
 }

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -4,6 +4,9 @@
  */
 function ffo_render_modules_shortcode() {
     global $post;
+    if ( ! ( $post instanceof WP_Post ) ) {
+        return '';
+    }
     $prefix = 'ffo_';
     $output = '';
     $pattern = get_post_meta( $post->ID, $prefix . 'layout_pattern', true );


### PR DESCRIPTION
## Summary
- avoid fatal error when shortcode is used outside of the main query
- bump plugin version
- document change in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856b9c0068c8329921f249441870ef1