### PR TITLE
Fix plugin fatal error on activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,16 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 
 ## Requirements
 
-The plugin relies on the CMB2 library. If CMB2 isn't available the builder tries
-to install the latest version automatically from WordPress.org. You can also
-install CMB2 manually or copy the library into `includes/cmb2/` so that
-`includes/cmb2/init.php` exists.
+The plugin relies on the CMB2 library. If CMB2 isn't available you will see an
+admin notice. Install the CMB2 plugin or copy the library into
+`includes/cmb2/` so that `includes/cmb2/init.php` exists.
 
 ## Installation
 
 1. Upload the plugin folder to your WordPress installation and activate it.
-2. The plugin attempts to fetch CMB2 on activation. If that fails, install CMB2
-   manually (see **Requirements**).
-3. Version 2.2.1 improves stability when the shortcode runs outside the main
-   query by checking that a valid post is available.
+2. Install and activate the CMB2 plugin if it isn't already present.
+3. Version 2.3.0 improves dependency handling and avoids fatal errors when CMB2
+   is missing.
 4. Create or edit a page/post and configure modules via the **Page Modules** meta
    box.
 5. Insert the shortcode `[free_flexio_modules]` into the content where the

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.2.1
+Version:           2.3.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,110 +14,50 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-/**
- * Ensure the CMB2 plugin is installed and activated.
- *
- * Attempts to fetch the latest version from WordPress.org when missing.
- */
-function ffo_maybe_install_cmb2() {
-    if ( defined( 'CMB2_LOADED' ) || class_exists( 'CMB2' ) ) {
-        return;
-    }
+define( 'FFO_VERSION', '2.3.0' );
+define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
+define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 
-    $bundled = plugin_dir_path( __FILE__ ) . 'includes/cmb2/init.php';
-    if ( file_exists( $bundled ) ) {
-        return;
-    }
-
-    include_once ABSPATH . 'wp-admin/includes/plugin.php';
-    include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-    include_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
-
-    $plugin = 'cmb2/init.php';
-
-    if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
-        if ( ! is_plugin_active( $plugin ) ) {
-            activate_plugin( $plugin );
-        }
-        return;
-    }
-
-    $api = plugins_api( 'plugin_information', [ 'slug' => 'cmb2', 'fields' => [ 'sections' => false ] ] );
-    if ( is_wp_error( $api ) ) {
-        return;
-    }
-
-    $upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
-    $result   = $upgrader->install( $api->download_link );
-    if ( ! is_wp_error( $result ) && file_exists( WP_PLUGIN_DIR . '/' . $plugin ) ) {
-        activate_plugin( $plugin );
+register_activation_hook( __FILE__, 'ffo_check_cmb2_on_activation' );
+function ffo_check_cmb2_on_activation() {
+    if ( ! ffo_cmb2_available() ) {
+        add_option( 'ffo_cmb2_missing', 1 );
     }
 }
-register_activation_hook( __FILE__, 'ffo_maybe_install_cmb2' );
-add_action( 'admin_init', 'ffo_maybe_install_cmb2' );
 
-/**
- * Check if CMB2 is available and, if not, display an admin notice.
- *
- * Prior versions tried to fetch CMB2 from GitHub automatically. In
- * restricted environments that behaviour caused failures. The plugin
- * now simply alerts administrators when CMB2 is missing so they can
- * install it manually (either as a separate plugin or by placing the
- * library inside <code>includes/cmb2/</code>).
- */
-add_action( 'admin_notices', 'ffo_check_cmb2_notice' );
-function ffo_check_cmb2_notice() {
-    if ( defined( 'CMB2_LOADED' ) || class_exists( 'CMB2' ) ) {
-        return;
+add_action( 'admin_notices', 'ffo_admin_cmb2_notice' );
+function ffo_admin_cmb2_notice() {
+    if ( get_option( 'ffo_cmb2_missing' ) ) {
+        echo '<div class="notice notice-warning"><p>' .
+            esc_html__( 'WP Overlay Restaurant requires the CMB2 plugin. Please install and activate CMB2 or place it in the plugin\'s includes/cmb2 directory.', 'freeflexoverlay' ) .
+            '</p></div>';
     }
-    $init = plugin_dir_path( __FILE__ ) . 'includes/cmb2/init.php';
-    if ( file_exists( $init ) ) {
-        require_once $init;
-        return;
-    }
-    echo '<div class="notice notice-warning"><p>' .
-        esc_html__(
-            'FreeFlexOverlay Builder requires the CMB2 library. The plugin attempts to install it automatically. ' .
-            'If this fails, please install the CMB2 plugin or place it in the plugin\'s includes/cmb2 directory.',
-            'freeflexoverlay'
-        ) .
-        '</p></div>';
 }
 
-/**
- * Initialization: load CMB2, meta boxes, render modules, shortcode
- */
-add_action( 'init', 'ffo_init_plugin', 5 );
+function ffo_cmb2_available() {
+    return class_exists( 'CMB2' ) || defined( 'CMB2_LOADED' ) || file_exists( FFO_DIR . 'includes/cmb2/init.php' );
+}
+
+add_action( 'plugins_loaded', 'ffo_init_plugin' );
 function ffo_init_plugin() {
-    $init = plugin_dir_path( __FILE__ ) . 'includes/cmb2/init.php';
-    if ( file_exists( $init ) ) {
-        require_once $init;
+    if ( ! ffo_cmb2_available() ) {
+        return;
     }
-    if ( class_exists( 'CMB2' ) && function_exists( 'new_cmb2_box' ) ) {
-        require_once plugin_dir_path( __FILE__ ) . 'includes/meta-boxes.php';
-        require_once plugin_dir_path( __FILE__ ) . 'includes/render-modules.php';
-        if ( function_exists( 'ffo_render_modules_shortcode' ) ) {
-            add_shortcode( 'free_flexio_modules', 'ffo_render_modules_shortcode' );
-        }
+
+    if ( ! ( class_exists( 'CMB2' ) || defined( 'CMB2_LOADED' ) ) && file_exists( FFO_DIR . 'includes/cmb2/init.php' ) ) {
+        require_once FFO_DIR . 'includes/cmb2/init.php';
     }
+
+    delete_option( 'ffo_cmb2_missing' );
+
+    require_once FFO_DIR . 'includes/meta-boxes.php';
+    require_once FFO_DIR . 'includes/render-modules.php';
+
+    add_shortcode( 'free_flexio_modules', 'ffo_render_modules_shortcode' );
 }
 
-/**
- * Enqueue assets
- */
 add_action( 'wp_enqueue_scripts', 'ffo_enqueue_assets' );
 function ffo_enqueue_assets() {
-    wp_enqueue_style(
-        'freeflexoverlay-style',
-        plugin_dir_url( __FILE__ ) . 'assets/style.css',
-        [],
-        '2.2.1'
-    );
-    wp_enqueue_script(
-        'freeflexoverlay-script',
-        plugin_dir_url( __FILE__ ) . 'assets/script.js',
-        [ 'jquery' ],
-        '2.2.1',
-        true
-    );
+    wp_enqueue_style( 'freeflexoverlay-style', FFO_URL . 'assets/style.css', [], FFO_VERSION );
+    wp_enqueue_script( 'freeflexoverlay-script', FFO_URL . 'assets/script.js', [ 'jquery' ], FFO_VERSION, true );
 }


### PR DESCRIPTION
## Summary
- rebuild plugin initialization to avoid activation fatal
- simplify CMB2 handling and admin notice
- document new dependency instructions

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bceeae848329884cb4598b8b8fd3