### PR TITLE
Fix plugin without CMB2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wp-overlay-restaurant
 
-wp-overlay-restaurant combines a small page builder with an overlay search. It ships a custom meta box powered by [CMB2](https://github.com/CMB2/CMB2) to create flexible fullwidth or grid modules on pages or posts. A simple JavaScript powered overlay search is included to search through a small data set which can be replaced with your own items.
+wp-overlay-restaurant combines a small page builder with an overlay search. It ships a custom meta box powered by [CMB2](https://github.com/CMB2/CMB2) to create flexible fullwidth or grid modules on pages or posts. If CMB2 is missing, a lightweight fallback meta box is used instead. A simple JavaScript powered overlay search is included to search through a small data set which can be replaced with your own items.
 
 ## Features
 
@@ -11,16 +11,13 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 
 ## Requirements
 
-The plugin relies on the CMB2 library. If CMB2 isn't available you will see an
-admin notice. Install the CMB2 plugin or copy the library into
-`includes/cmb2/` so that `includes/cmb2/init.php` exists.
+The plugin works best with the CMB2 library. When CMB2 is not present a simplified built-in meta box is loaded. You can still install the CMB2 plugin or copy the library into `includes/cmb2/` so that `includes/cmb2/init.php` exists to use the full CMB2 interface.
 
 ## Installation
 
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. Install and activate the CMB2 plugin if it isn't already present.
-3. Version 2.3.0 improves dependency handling and avoids fatal errors when CMB2
-   is missing.
+3. Version 2.4.0 bundles a fallback meta box so the plugin works even without CMB2.
 4. Create or edit a page/post and configure modules via the **Page Modules** meta
    box.
 5. Insert the shortcode `[free_flexio_modules]` into the content where the

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,0 +1,10 @@
+#ffo-modules .ffo-module {
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 10px;
+  background: #f9f9f9;
+}
+.ffo-remove-module {
+  color: #b32d2e;
+  text-decoration: none;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,12 @@
+jQuery(document).ready(function($){
+  $('#ffo-add-module').on('click', function(e){
+    e.preventDefault();
+    var index = $('#ffo-modules .ffo-module').length;
+    var tpl = $('#ffo-module-template').html().replace(/__index__/g, index);
+    $('#ffo-modules').append(tpl);
+  });
+  $(document).on('click', '.ffo-remove-module', function(e){
+    e.preventDefault();
+    $(this).closest('.ffo-module').remove();
+  });
+});

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.3.0
+Version:           2.4.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,7 +14,7 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'FFO_VERSION', '2.3.0' );
+define( 'FFO_VERSION', '2.4.0' );
 define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 
@@ -40,19 +40,19 @@ function ffo_cmb2_available() {
 
 add_action( 'plugins_loaded', 'ffo_init_plugin' );
 function ffo_init_plugin() {
-    if ( ! ffo_cmb2_available() ) {
-        return;
+    if ( ffo_cmb2_available() ) {
+        if ( ! ( class_exists( 'CMB2' ) || defined( 'CMB2_LOADED' ) ) && file_exists( FFO_DIR . 'includes/cmb2/init.php' ) ) {
+            require_once FFO_DIR . 'includes/cmb2/init.php';
+        }
+
+        delete_option( 'ffo_cmb2_missing' );
+
+        require_once FFO_DIR . 'includes/meta-boxes.php';
+    } else {
+        require_once FFO_DIR . 'includes/fallback-meta-boxes.php';
     }
 
-    if ( ! ( class_exists( 'CMB2' ) || defined( 'CMB2_LOADED' ) ) && file_exists( FFO_DIR . 'includes/cmb2/init.php' ) ) {
-        require_once FFO_DIR . 'includes/cmb2/init.php';
-    }
-
-    delete_option( 'ffo_cmb2_missing' );
-
-    require_once FFO_DIR . 'includes/meta-boxes.php';
     require_once FFO_DIR . 'includes/render-modules.php';
-
     add_shortcode( 'free_flexio_modules', 'ffo_render_modules_shortcode' );
 }
 
@@ -60,4 +60,12 @@ add_action( 'wp_enqueue_scripts', 'ffo_enqueue_assets' );
 function ffo_enqueue_assets() {
     wp_enqueue_style( 'freeflexoverlay-style', FFO_URL . 'assets/style.css', [], FFO_VERSION );
     wp_enqueue_script( 'freeflexoverlay-script', FFO_URL . 'assets/script.js', [ 'jquery' ], FFO_VERSION, true );
+}
+
+add_action( 'admin_enqueue_scripts', 'ffo_admin_assets' );
+function ffo_admin_assets( $hook ) {
+    if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+        wp_enqueue_script( 'freeflexoverlay-admin', FFO_URL . 'assets/admin.js', [ 'jquery' ], FFO_VERSION, true );
+        wp_enqueue_style( 'freeflexoverlay-admin-style', FFO_URL . 'assets/admin.css', [], FFO_VERSION );
+    }
 }

--- a/includes/fallback-meta-boxes.php
+++ b/includes/fallback-meta-boxes.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Fallback meta boxes when CMB2 is missing
+ */
+add_action( 'add_meta_boxes', 'ffo_add_fallback_metabox' );
+function ffo_add_fallback_metabox() {
+    add_meta_box( 'ffo_modules', __( 'Page Modules', 'freeflexoverlay' ), 'ffo_render_fallback_metabox', [ 'post', 'page' ] );
+}
+
+function ffo_render_fallback_metabox( $post ) {
+    wp_nonce_field( 'ffo_save_modules', 'ffo_modules_nonce' );
+    $prefix = 'ffo_';
+    $layout_pattern = get_post_meta( $post->ID, $prefix . 'layout_pattern', true );
+    $modules = get_post_meta( $post->ID, $prefix . 'modules_group', true );
+    if ( ! is_array( $modules ) ) {
+        $modules = [];
+    }
+    ?>
+    <p>
+        <label for="ffo_layout_pattern"><?php esc_html_e( 'Layout Pattern', 'freeflexoverlay' ); ?></label>
+        <select id="ffo_layout_pattern" name="ffo_layout_pattern">
+            <option value="custom" <?php selected( $layout_pattern, 'custom' ); ?>><?php esc_html_e( 'Custom Modules', 'freeflexoverlay' ); ?></option>
+            <option value="pattern1" <?php selected( $layout_pattern, 'pattern1' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
+            <option value="fullwidth" <?php selected( $layout_pattern, 'fullwidth' ); ?>><?php esc_html_e( 'Fullwidth Only', 'freeflexoverlay' ); ?></option>
+            <option value="grid" <?php selected( $layout_pattern, 'grid' ); ?>><?php esc_html_e( '2×2 Grid Only', 'freeflexoverlay' ); ?></option>
+        </select>
+    </p>
+    <div id="ffo-modules">
+    <?php
+    $i = 0;
+    foreach ( $modules as $mod ) {
+        ffo_render_single_module( $i, $mod );
+        $i++;
+    }
+    ?>
+    </div>
+    <p><button type="button" id="ffo-add-module" class="button"><?php esc_html_e( 'Add Module', 'freeflexoverlay' ); ?></button></p>
+    <div id="ffo-module-template" style="display:none;">
+        <?php ffo_render_single_module( '__index__', [] ); ?>
+    </div>
+    <?php
+}
+
+function ffo_render_single_module( $index, $mod ) {
+    ?>
+    <div class="ffo-module">
+        <p>
+            <label><?php esc_html_e( 'Layout Type', 'freeflexoverlay' ); ?>
+                <select name="ffo_modules_group[<?php echo esc_attr( $index ); ?>][layout_type]">
+                    <option value="fullwidth" <?php if ( isset( $mod['layout_type'] ) && $mod['layout_type'] === 'fullwidth' ) echo 'selected'; ?>><?php esc_html_e( 'Fullwidth', 'freeflexoverlay' ); ?></option>
+                    <option value="grid" <?php if ( isset( $mod['layout_type'] ) && $mod['layout_type'] === 'grid' ) echo 'selected'; ?>><?php esc_html_e( '2×2 Grid', 'freeflexoverlay' ); ?></option>
+                </select>
+            </label>
+            <a href="#" class="ffo-remove-module" style="margin-left:10px;"><?php esc_html_e( 'Remove', 'freeflexoverlay' ); ?></a>
+        </p>
+        <p>
+            <label><?php esc_html_e( 'Fullwidth Content', 'freeflexoverlay' ); ?><br/>
+                <textarea name="ffo_modules_group[<?php echo esc_attr( $index ); ?>][full_content]" rows="5" style="width:100%;"><?php echo isset( $mod['full_content'] ) ? esc_textarea( $mod['full_content'] ) : ''; ?></textarea>
+            </label>
+        </p>
+        <?php for ( $j = 1; $j <= 4; $j++ ) : ?>
+            <p>
+                <label><?php printf( esc_html__( 'Grid Item %d', 'freeflexoverlay' ), $j ); ?><br/>
+                    <textarea name="ffo_modules_group[<?php echo esc_attr( $index ); ?>][grid_item_<?php echo $j; ?>]" rows="3" style="width:100%;"><?php echo isset( $mod['grid_item_' . $j] ) ? esc_textarea( $mod['grid_item_' . $j] ) : ''; ?></textarea>
+                </label>
+            </p>
+        <?php endfor; ?>
+    </div>
+    <?php
+}
+
+add_action( 'save_post', 'ffo_save_fallback_metabox' );
+function ffo_save_fallback_metabox( $post_id ) {
+    if ( ! isset( $_POST['ffo_modules_nonce'] ) || ! wp_verify_nonce( $_POST['ffo_modules_nonce'], 'ffo_save_modules' ) ) {
+        return;
+    }
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+        return;
+    }
+    $prefix = 'ffo_';
+    if ( isset( $_POST['ffo_layout_pattern'] ) ) {
+        update_post_meta( $post_id, $prefix . 'layout_pattern', sanitize_text_field( $_POST['ffo_layout_pattern'] ) );
+    }
+    if ( isset( $_POST['ffo_modules_group'] ) && is_array( $_POST['ffo_modules_group'] ) ) {
+        $modules = [];
+        foreach ( $_POST['ffo_modules_group'] as $module ) {
+            $modules[] = [
+                'layout_type'  => isset( $module['layout_type'] ) ? sanitize_text_field( $module['layout_type'] ) : '',
+                'full_content' => isset( $module['full_content'] ) ? wp_kses_post( $module['full_content'] ) : '',
+                'grid_item_1'  => isset( $module['grid_item_1'] ) ? wp_kses_post( $module['grid_item_1'] ) : '',
+                'grid_item_2'  => isset( $module['grid_item_2'] ) ? wp_kses_post( $module['grid_item_2'] ) : '',
+                'grid_item_3'  => isset( $module['grid_item_3'] ) ? wp_kses_post( $module['grid_item_3'] ) : '',
+                'grid_item_4'  => isset( $module['grid_item_4'] ) ? wp_kses_post( $module['grid_item_4'] ) : '',
+            ];
+        }
+        update_post_meta( $post_id, $prefix . 'modules_group', $modules );
+    } else {
+        delete_post_meta( $post_id, $prefix . 'modules_group' );
+    }
+}


### PR DESCRIPTION
## Summary
- load fallback meta boxes when CMB2 is missing
- add new admin JS and CSS
- wire up admin assets in plugin loader
- clarify fallback behaviour in the README

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856be26c7548329a0f76471cd8bc1fb