### PR TITLE
Add reusable layout CPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 - Add repeating modules to pages and posts (fullwidth sections or 2×2 grids)
 - Choose between predefined layout patterns or build custom sequences
 - Shortcode `[free_flexio_modules]` renders the modules and the overlay search
+- Create reusable layouts in the **Overlay Layouts** menu and reference them via `[free_flexio_modules id="123"]`
 - Overlay search shows results in a centered modal
 
 ## Requirements
@@ -17,11 +18,9 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. Install and activate the CMB2 plugin if it isn't already present.
-3. Version 2.4.0 bundles a fallback meta box so the plugin works even without CMB2.
-4. Create or edit a page/post and configure modules via the **Page Modules** meta
-   box.
-5. Insert the shortcode `[free_flexio_modules]` into the content where the
-   modules and search should appear.
+3. Version 2.5.0 bundles a fallback meta box so the plugin works even without CMB2.
+4. Create a new entry under **Overlay Layouts** and configure modules via the **Page Modules** meta box.
+5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the ID of your layout.
 
 ## Customising the search
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.4.0
+Version:           2.5.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,7 +14,7 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'FFO_VERSION', '2.4.0' );
+define( 'FFO_VERSION', '2.5.0' );
 define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 
@@ -54,6 +54,31 @@ function ffo_init_plugin() {
 
     require_once FFO_DIR . 'includes/render-modules.php';
     add_shortcode( 'free_flexio_modules', 'ffo_render_modules_shortcode' );
+}
+
+add_action( 'init', 'ffo_register_layout_cpt' );
+function ffo_register_layout_cpt() {
+    $labels = array(
+        'name'               => __( 'Overlay Layouts', 'freeflexoverlay' ),
+        'singular_name'      => __( 'Overlay Layout', 'freeflexoverlay' ),
+        'add_new'            => __( 'Add Layout', 'freeflexoverlay' ),
+        'add_new_item'       => __( 'Add New Layout', 'freeflexoverlay' ),
+        'edit_item'          => __( 'Edit Layout', 'freeflexoverlay' ),
+        'new_item'           => __( 'New Layout', 'freeflexoverlay' ),
+        'view_item'          => __( 'View Layout', 'freeflexoverlay' ),
+        'search_items'       => __( 'Search Layouts', 'freeflexoverlay' ),
+        'not_found'          => __( 'No layouts found.', 'freeflexoverlay' ),
+        'not_found_in_trash' => __( 'No layouts found in Trash.', 'freeflexoverlay' ),
+    );
+
+    $args = array(
+        'labels'       => $labels,
+        'public'       => false,
+        'show_ui'      => true,
+        'show_in_menu' => true,
+        'supports'     => array( 'title' ),
+    );
+    register_post_type( 'ffo_layout', $args );
 }
 
 add_action( 'wp_enqueue_scripts', 'ffo_enqueue_assets' );

--- a/includes/fallback-meta-boxes.php
+++ b/includes/fallback-meta-boxes.php
@@ -4,7 +4,7 @@
  */
 add_action( 'add_meta_boxes', 'ffo_add_fallback_metabox' );
 function ffo_add_fallback_metabox() {
-    add_meta_box( 'ffo_modules', __( 'Page Modules', 'freeflexoverlay' ), 'ffo_render_fallback_metabox', [ 'post', 'page' ] );
+    add_meta_box( 'ffo_modules', __( 'Page Modules', 'freeflexoverlay' ), 'ffo_render_fallback_metabox', [ 'post', 'page', 'ffo_layout' ] );
 }
 
 function ffo_render_fallback_metabox( $post ) {

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -8,7 +8,7 @@ function ffo_register_module_metabox() {
     $cmb = new_cmb2_box( array(
         'id'           => $prefix . 'modules',
         'title'        => __( 'Page Modules', 'freeflexoverlay' ),
-        'object_types' => array( 'page', 'post' ),
+        'object_types' => array( 'page', 'post', 'ffo_layout' ),
     ) );
     // Layout pattern select
     $cmb->add_field( array(

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -2,14 +2,19 @@
 /**
  * Render modules and overlay search
  */
-function ffo_render_modules_shortcode() {
+function ffo_render_modules_shortcode( $atts = array() ) {
     global $post;
-    if ( ! ( $post instanceof WP_Post ) ) {
+    $atts = shortcode_atts( array( 'id' => 0 ), $atts, 'free_flexio_modules' );
+    $layout_post = $post;
+    if ( ! empty( $atts['id'] ) ) {
+        $layout_post = get_post( (int) $atts['id'] );
+    }
+    if ( ! ( $layout_post instanceof WP_Post ) ) {
         return '';
     }
     $prefix = 'ffo_';
     $output = '';
-    $pattern = get_post_meta( $post->ID, $prefix . 'layout_pattern', true );
+    $pattern = get_post_meta( $layout_post->ID, $prefix . 'layout_pattern', true );
     if ( $pattern && $pattern !== 'custom' ) {
         if ( $pattern === 'pattern1' ) {
             $output .= '<div class="ffo-fullwidth">' . __( 'Standard Fullwidth-Content', 'freeflexoverlay' ) . '</div>';
@@ -21,7 +26,7 @@ function ffo_render_modules_shortcode() {
             $output .= '<div class="ffo-grid"><!-- 4 Items --></div>';
         }
     } else {
-        $modules = get_post_meta( $post->ID, $prefix . 'modules_group', true );
+        $modules = get_post_meta( $layout_post->ID, $prefix . 'modules_group', true );
         if ( ! empty( $modules ) ) {
             foreach ( $modules as $mod ) {
                 if ( isset( $mod['layout_type'] ) && $mod['layout_type'] === 'fullwidth' ) {


### PR DESCRIPTION
## Summary
- allow managing module sets globally via new `Overlay Layouts` custom post type
- load meta boxes on the new post type
- update shortcode to accept `id` attribute to pull layout from CPT
- document new workflow in README
- bump plugin version to 2.5.0

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c2acfe1883299bc175d76726c4a5