### PR TITLE
Allow layout lookup by slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 - Add repeating modules to pages and posts (fullwidth sections or 2×2 grids)
 - Choose between predefined layout patterns or build custom sequences
 - Shortcode `[free_flexio_modules]` renders the modules and the overlay search
-- Create reusable layouts in the **Overlay Layouts** menu and reference them via `[free_flexio_modules id="123"]`
+- Create reusable layouts in the **Overlay Layouts** menu and reference them via `[free_flexio_modules id="123"]` (or by slug, e.g. `[free_flexio_modules id="startseite"]`)
 - Overlay search shows results in a centered modal
 
 ## Requirements
@@ -20,7 +20,7 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 2. Install and activate the CMB2 plugin if it isn't already present.
 3. Version 2.5.0 bundles a fallback meta box so the plugin works even without CMB2.
 4. Create a new entry under **Overlay Layouts** and configure modules via the **Page Modules** meta box.
-5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the ID of your layout.
+5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the layout ID. Slugs work as well, e.g. `[free_flexio_modules id="startseite"]`.
 
 ## Customising the search
 

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -7,7 +7,11 @@ function ffo_render_modules_shortcode( $atts = array() ) {
     $atts = shortcode_atts( array( 'id' => 0 ), $atts, 'free_flexio_modules' );
     $layout_post = $post;
     if ( ! empty( $atts['id'] ) ) {
-        $layout_post = get_post( (int) $atts['id'] );
+        if ( is_numeric( $atts['id'] ) ) {
+            $layout_post = get_post( (int) $atts['id'] );
+        } else {
+            $layout_post = get_page_by_path( sanitize_title( $atts['id'] ), OBJECT, 'ffo_layout' );
+        }
     }
     if ( ! ( $layout_post instanceof WP_Post ) ) {
         return '';


### PR DESCRIPTION
## Summary
- allow passing a layout slug to `[free_flexio_modules]`
- document slug usage in README

## Testing
- `php -l includes/render-modules.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c95466d083299f96de3c027171eb