### PR TITLE
Add fullwidth grid layout

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -8,3 +8,7 @@
   color: #b32d2e;
   text-decoration: none;
 }
+
+/* Fields for fullwidth-2x2-fullwidth layout */
+.ffo-fw2x2fw-field { display: none; }
+#ffo-fw2x2fw-fields { display: none; margin-top: 10px; }

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -27,4 +27,18 @@ jQuery(document).ready(function($){
   $('#ffo-modules .ffo-module').each(function(){
     updateVisibility($(this));
   });
+
+  function updateLayoutFields(){
+    var val = $('#ffo_layout_pattern').val();
+    if(val === 'fullwidth-2x2-fullwidth'){
+      $('.ffo-fw2x2fw-field').closest('.cmb-row').show();
+      $('#ffo-fw2x2fw-fields').show();
+    }else{
+      $('.ffo-fw2x2fw-field').closest('.cmb-row').hide();
+      $('#ffo-fw2x2fw-fields').hide();
+    }
+  }
+
+  $('#ffo_layout_pattern').on('change', updateLayoutFields);
+  updateLayoutFields();
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -23,3 +23,8 @@
 #ffo-overlay-close { position: absolute; top: 0.5rem; right: 0.75rem; background: transparent; border: none; font-size: 1.5rem; color: #fff; cursor: pointer; }
 #ffo-search-results .ffo-item { background: #222; margin: 0.5rem 0; padding: 0.75rem 1rem; border-radius: 4px; }
 #ffo-search-results .ffo-item-title { margin: 0; font-size: 1.1rem; }
+
+/* Layout fullwidth-2x2-fullwidth */
+.pm-fullwidth { width: 100%; padding: 2rem; background: #f5f5f5; margin-bottom: 2rem; }
+.pm-grid--2x2 { display: grid; grid-template-columns: repeat(2,1fr); gap: 1rem; margin-bottom: 2rem; }
+.pm-grid__item { background: #fff; padding: 1rem; border: 1px solid #ddd; }

--- a/includes/fallback-meta-boxes.php
+++ b/includes/fallback-meta-boxes.php
@@ -22,6 +22,7 @@ function ffo_render_fallback_metabox( $post ) {
             <option value="custom" <?php selected( $layout_pattern, 'custom' ); ?>><?php esc_html_e( 'Custom Modules', 'freeflexoverlay' ); ?></option>
             <option value="pattern1" <?php selected( $layout_pattern, 'pattern1' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
             <option value="pattern2" <?php selected( $layout_pattern, 'pattern2' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
+            <option value="fullwidth-2x2-fullwidth" <?php selected( $layout_pattern, 'fullwidth-2x2-fullwidth' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
             <option value="fullwidth" <?php selected( $layout_pattern, 'fullwidth' ); ?>><?php esc_html_e( 'Fullwidth Only', 'freeflexoverlay' ); ?></option>
             <option value="grid" <?php selected( $layout_pattern, 'grid' ); ?>><?php esc_html_e( '2×2 Grid Only', 'freeflexoverlay' ); ?></option>
         </select>
@@ -38,6 +39,26 @@ function ffo_render_fallback_metabox( $post ) {
     <p><button type="button" id="ffo-add-module" class="button"><?php esc_html_e( 'Add Module', 'freeflexoverlay' ); ?></button></p>
     <div id="ffo-module-template" style="display:none;">
         <?php ffo_render_single_module( '__index__', [] ); ?>
+    </div>
+
+    <div id="ffo-fw2x2fw-fields">
+        <p>
+            <label><?php esc_html_e( 'Fullwidth Top', 'freeflexoverlay' ); ?><br/>
+                <textarea name="ffo_fullwidth_top" rows="5" style="width:100%;"><?php echo esc_textarea( get_post_meta( $post->ID, $prefix . 'fullwidth_top', true ) ); ?></textarea>
+            </label>
+        </p>
+        <?php for ( $j = 1; $j <= 4; $j++ ) : ?>
+            <p>
+                <label><?php printf( esc_html__( 'Grid Item %d', 'freeflexoverlay' ), $j ); ?><br/>
+                    <textarea name="ffo_grid_item_<?php echo $j; ?>" rows="3" style="width:100%;"><?php echo esc_textarea( get_post_meta( $post->ID, $prefix . 'grid_item_' . $j, true ) ); ?></textarea>
+                </label>
+            </p>
+        <?php endfor; ?>
+        <p>
+            <label><?php esc_html_e( 'Fullwidth Bottom', 'freeflexoverlay' ); ?><br/>
+                <textarea name="ffo_fullwidth_bottom" rows="5" style="width:100%;"><?php echo esc_textarea( get_post_meta( $post->ID, $prefix . 'fullwidth_bottom', true ) ); ?></textarea>
+            </label>
+        </p>
     </div>
     <?php
 }
@@ -100,5 +121,16 @@ function ffo_save_fallback_metabox( $post_id ) {
         update_post_meta( $post_id, $prefix . 'modules_group', $modules );
     } else {
         delete_post_meta( $post_id, $prefix . 'modules_group' );
+    }
+
+    if ( isset( $_POST['ffo_layout_pattern'] ) && $_POST['ffo_layout_pattern'] === 'fullwidth-2x2-fullwidth' ) {
+        $fields = array( 'fullwidth_top', 'grid_item_1', 'grid_item_2', 'grid_item_3', 'grid_item_4', 'fullwidth_bottom' );
+        foreach ( $fields as $field ) {
+            if ( isset( $_POST[ 'ffo_' . $field ] ) ) {
+                update_post_meta( $post_id, $prefix . $field, wp_kses_post( $_POST[ 'ffo_' . $field ] ) );
+            } else {
+                delete_post_meta( $post_id, $prefix . $field );
+            }
+        }
     }
 }

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -16,11 +16,12 @@ function ffo_register_module_metabox() {
         'id'      => $prefix . 'layout_pattern',
         'type'    => 'select',
         'options' => array(
-            'custom'    => __( 'Custom Modules', 'freeflexoverlay' ),
-            'pattern1'  => __( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ),
-            'pattern2'  => __( 'Fullwidth – 2×2 – 2×2 – Fullwidth', 'freeflexoverlay' ),
-            'fullwidth' => __( 'Fullwidth Only', 'freeflexoverlay' ),
-            'grid'      => __( '2×2 Grid Only', 'freeflexoverlay' ),
+            'custom'                     => __( 'Custom Modules', 'freeflexoverlay' ),
+            'pattern1'                   => __( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ),
+            'pattern2'                   => __( 'Fullwidth – 2×2 – 2×2 – Fullwidth', 'freeflexoverlay' ),
+            'fullwidth-2x2-fullwidth'    => __( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ),
+            'fullwidth'                  => __( 'Fullwidth Only', 'freeflexoverlay' ),
+            'grid'                       => __( '2×2 Grid Only', 'freeflexoverlay' ),
         ),
         'default' => 'custom',
     ) );
@@ -66,4 +67,29 @@ function ffo_register_module_metabox() {
             ),
         ) );
     }
+
+    // Fields for the "fullwidth-2x2-fullwidth" pattern
+    $cmb->add_field( array(
+        'name'        => __( 'Fullwidth Top', 'freeflexoverlay' ),
+        'id'          => $prefix . 'fullwidth_top',
+        'type'        => 'wysiwyg',
+        'row_classes' => 'ffo-fw2x2fw-field',
+        'options'     => array( 'textarea_rows' => 5 ),
+    ) );
+    for ( $i = 1; $i <= 4; $i++ ) {
+        $cmb->add_field( array(
+            'name'        => sprintf( __( 'Grid Item %d', 'freeflexoverlay' ), $i ),
+            'id'          => $prefix . 'grid_item_' . $i,
+            'type'        => 'wysiwyg',
+            'row_classes' => 'ffo-fw2x2fw-field',
+            'options'     => array( 'textarea_rows' => 3 ),
+        ) );
+    }
+    $cmb->add_field( array(
+        'name'        => __( 'Fullwidth Bottom', 'freeflexoverlay' ),
+        'id'          => $prefix . 'fullwidth_bottom',
+        'type'        => 'wysiwyg',
+        'row_classes' => 'ffo-fw2x2fw-field',
+        'options'     => array( 'textarea_rows' => 5 ),
+    ) );
 }

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -21,7 +21,12 @@ function ffo_render_modules_shortcode( $atts = array() ) {
     $pattern = get_post_meta( $layout_post->ID, $prefix . 'layout_pattern', true );
     $modules = get_post_meta( $layout_post->ID, $prefix . 'modules_group', true );
 
-    if ( $pattern && $pattern !== 'custom' && empty( $modules ) ) {
+    if ( $pattern === 'fullwidth-2x2-fullwidth' ) {
+        ob_start();
+        $post = $layout_post;
+        include FFO_DIR . 'templates/layout-fullwidth-2x2-fullwidth.php';
+        $output .= ob_get_clean();
+    } elseif ( $pattern && $pattern !== 'custom' && empty( $modules ) ) {
         // When no custom modules exist output simple placeholders for the
         // selected pattern. This keeps backward compatibility with older
         // behaviour where the pattern rendered static demo content.

--- a/templates/layout-fullwidth-2x2-fullwidth.php
+++ b/templates/layout-fullwidth-2x2-fullwidth.php
@@ -1,0 +1,11 @@
+<div class="pm-fullwidth pm-fullwidth--top">
+  <?= apply_filters('the_content', get_post_meta($post->ID,'fullwidth_top',true)); ?>
+</div>
+<div class="pm-grid pm-grid--2x2">
+  <?php for($i=1;$i<=4;$i++): ?>
+    <div class="pm-grid__item"><?= apply_filters('the_content', get_post_meta($post->ID,"grid_item_$i",true)); ?></div>
+  <?php endfor; ?>
+</div>
+<div class="pm-fullwidth pm-fullwidth--bottom">
+  <?= apply_filters('the_content', get_post_meta($post->ID,'fullwidth_bottom',true)); ?>
+</div>


### PR DESCRIPTION
## Summary
- add new 'Fullwidth – 2×2 – Fullwidth' layout option
- support new layout fields in both CMB2 and fallback meta boxes
- render new layout via a template file
- add admin JS/CSS to toggle fields
- add frontend styles for the layout

## Testing
- `php -l` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1c8505083298b90eee4af2d95af