### PR TITLE
Fix layout field prefixes and clean options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. Install and activate the CMB2 plugin if it isn't already present.
-3. Version 2.6.0 bundles a fallback meta box so the plugin works even without CMB2.
+3. Version 2.6.1 bundles a fallback meta box so the plugin works even without CMB2.
 4. Create a new entry under **Overlay Layouts** and configure modules via the **Page Modules** meta box.
 5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the layout ID. Slugs work as well, e.g. `[free_flexio_modules id="startseite"]`.
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -33,9 +33,13 @@ jQuery(document).ready(function($){
     if(val === 'fullwidth-2x2-fullwidth'){
       $('.ffo-fw2x2fw-field').closest('.cmb-row').show();
       $('#ffo-fw2x2fw-fields').show();
+      $('.ffo-modules-group').closest('.cmb-row').hide();
+      $('#ffo-modules, #ffo-add-module, #ffo-module-template').hide();
     }else{
       $('.ffo-fw2x2fw-field').closest('.cmb-row').hide();
       $('#ffo-fw2x2fw-fields').hide();
+      $('.ffo-modules-group').closest('.cmb-row').show();
+      $('#ffo-modules, #ffo-add-module, #ffo-module-template').show();
     }
   }
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.6.0
+Version:           2.6.1
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,7 +14,7 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'FFO_VERSION', '2.6.0' );
+define( 'FFO_VERSION', '2.6.1' );
 define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/fallback-meta-boxes.php
+++ b/includes/fallback-meta-boxes.php
@@ -20,7 +20,6 @@ function ffo_render_fallback_metabox( $post ) {
         <label for="ffo_layout_pattern"><?php esc_html_e( 'Layout Pattern', 'freeflexoverlay' ); ?></label>
         <select id="ffo_layout_pattern" name="ffo_layout_pattern">
             <option value="custom" <?php selected( $layout_pattern, 'custom' ); ?>><?php esc_html_e( 'Custom Modules', 'freeflexoverlay' ); ?></option>
-            <option value="pattern1" <?php selected( $layout_pattern, 'pattern1' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
             <option value="pattern2" <?php selected( $layout_pattern, 'pattern2' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
             <option value="fullwidth-2x2-fullwidth" <?php selected( $layout_pattern, 'fullwidth-2x2-fullwidth' ); ?>><?php esc_html_e( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ); ?></option>
             <option value="fullwidth" <?php selected( $layout_pattern, 'fullwidth' ); ?>><?php esc_html_e( 'Fullwidth Only', 'freeflexoverlay' ); ?></option>

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -17,7 +17,6 @@ function ffo_register_module_metabox() {
         'type'    => 'select',
         'options' => array(
             'custom'                     => __( 'Custom Modules', 'freeflexoverlay' ),
-            'pattern1'                   => __( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ),
             'pattern2'                   => __( 'Fullwidth – 2×2 – 2×2 – Fullwidth', 'freeflexoverlay' ),
             'fullwidth-2x2-fullwidth'    => __( 'Fullwidth – 2×2 – Fullwidth', 'freeflexoverlay' ),
             'fullwidth'                  => __( 'Fullwidth Only', 'freeflexoverlay' ),
@@ -27,9 +26,10 @@ function ffo_register_module_metabox() {
     ) );
     // Module group
     $group_id = $cmb->add_field( array(
-        'id'      => $prefix . 'modules_group',
-        'type'    => 'group',
-        'options' => array(
+        'id'         => $prefix . 'modules_group',
+        'type'       => 'group',
+        'row_classes' => 'ffo-modules-group',
+        'options'    => array(
             'group_title'   => __( 'Modul {#}', 'freeflexoverlay' ),
             'add_button'    => __( 'Hinzufügen', 'freeflexoverlay' ),
             'remove_button' => __( 'Entfernen', 'freeflexoverlay' ),

--- a/templates/layout-fullwidth-2x2-fullwidth.php
+++ b/templates/layout-fullwidth-2x2-fullwidth.php
@@ -1,11 +1,13 @@
 <div class="pm-fullwidth pm-fullwidth--top">
-  <?= apply_filters('the_content', get_post_meta($post->ID,'fullwidth_top',true)); ?>
+  <?= apply_filters('the_content', get_post_meta( $post->ID, 'ffo_fullwidth_top', true ) ); ?>
 </div>
 <div class="pm-grid pm-grid--2x2">
-  <?php for($i=1;$i<=4;$i++): ?>
-    <div class="pm-grid__item"><?= apply_filters('the_content', get_post_meta($post->ID,"grid_item_$i",true)); ?></div>
+  <?php for ( $i = 1; $i <= 4; $i++ ) : ?>
+    <div class="pm-grid__item">
+      <?= apply_filters( 'the_content', get_post_meta( $post->ID, "ffo_grid_item_{$i}", true ) ); ?>
+    </div>
   <?php endfor; ?>
 </div>
 <div class="pm-fullwidth pm-fullwidth--bottom">
-  <?= apply_filters('the_content', get_post_meta($post->ID,'fullwidth_bottom',true)); ?>
+  <?= apply_filters('the_content', get_post_meta( $post->ID, 'ffo_fullwidth_bottom', true ) ); ?>
 </div>


### PR DESCRIPTION
## Summary
- fix layout template to use correct `ffo_` prefixed fields
- remove duplicate layout option from the meta boxes
- hide module group when using the extended layout
- bump version to 2.6.1

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685812cd7eb083299c9cf3a31766a0c4