### PR TITLE
Fix numeric layout ID fallback

### DIFF
--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -9,6 +9,9 @@ function ffo_render_modules_shortcode( $atts = array() ) {
     if ( ! empty( $atts['id'] ) ) {
         if ( is_numeric( $atts['id'] ) ) {
             $layout_post = get_post( (int) $atts['id'] );
+            if ( ! $layout_post || $layout_post->post_type !== 'ffo_layout' ) {
+                $layout_post = get_page_by_path( sanitize_title( $atts['id'] ), OBJECT, 'ffo_layout' );
+            }
         } else {
             $layout_post = get_page_by_path( sanitize_title( $atts['id'] ), OBJECT, 'ffo_layout' );
         }


### PR DESCRIPTION
## Summary
- ensure numeric `id` in shortcode falls back to slug lookup if the post isn't an overlay layout

## Testing
- `php -l includes/render-modules.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581648a4688329a870629f64369c8d