### PR TITLE
Add shortcode column in admin overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ wp-overlay-restaurant combines a small page builder with an overlay search. It s
 - Selecting a predefined pattern now auto-populates matching modules for quick editing
 - Shortcode `[free_flexio_modules]` renders the modules and the overlay search
 - Create reusable layouts in the **Overlay Layouts** menu and reference them via `[free_flexio_modules id="123"]` (or by slug, e.g. `[free_flexio_modules id="startseite"]`)
+- Overlay layout lists in the admin now show the shortcode for each layout
 - Overlay search shows results in a centered modal
 
 ## Requirements
@@ -19,7 +20,7 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. Install and activate the CMB2 plugin if it isn't already present.
-3. Version 2.6.1 bundles a fallback meta box so the plugin works even without CMB2.
+3. Version 2.6.2 bundles a fallback meta box so the plugin works even without CMB2.
 4. Create a new entry under **Overlay Layouts** and configure modules via the **Page Modules** meta box.
 5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the layout ID. Slugs work as well, e.g. `[free_flexio_modules id="startseite"]`.
 

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid) und mittig zentrierte Overlay-Suche.
-Version:           2.6.1
+Version:           2.6.2
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,7 +14,7 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'FFO_VERSION', '2.6.1' );
+define( 'FFO_VERSION', '2.6.2' );
 define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 
@@ -79,6 +79,25 @@ function ffo_register_layout_cpt() {
         'supports'     => array( 'title' ),
     );
     register_post_type( 'ffo_layout', $args );
+}
+
+add_filter( 'manage_ffo_layout_posts_columns', 'ffo_layout_add_shortcode_column' );
+function ffo_layout_add_shortcode_column( $columns ) {
+    $new = array();
+    foreach ( $columns as $key => $label ) {
+        $new[ $key ] = $label;
+        if ( 'title' === $key ) {
+            $new['ffo_shortcode'] = __( 'Shortcode', 'freeflexoverlay' );
+        }
+    }
+    return $new;
+}
+
+add_action( 'manage_ffo_layout_posts_custom_column', 'ffo_layout_render_shortcode_column', 10, 2 );
+function ffo_layout_render_shortcode_column( $column, $post_id ) {
+    if ( 'ffo_shortcode' === $column ) {
+        echo '<code>[free_flexio_modules id="' . (int) $post_id . '"]</code>';
+    }
 }
 
 add_action( 'wp_enqueue_scripts', 'ffo_enqueue_assets' );


### PR DESCRIPTION
## Summary
- display shortcode in Overlay Layouts list
- document new listing feature
- bump version to 2.6.2

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858176fa29c832984d78d7120768c71