### PR TITLE
Add overlay component

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,24 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 ## License
 
 This project is released under the MIT license. See `LICENSE` for details.
+
+## Overlay Component
+
+The `assets/overlay.js` and `assets/overlay.css` files provide a configurable overlay.
+Call `showOverlay()` with your texts to display it. The `templates/overlay-template.html` file shows the data attributes you can use.
+You can also attach the overlay to any element with `showOverlayFromElement(element)` which reads those attributes.
+
+Example:
+```html
+<script>
+showOverlay({
+  overlayTitle: 'Titel',
+  tile1Content: 'Kachel 1',
+  tile2Content: 'Kachel 2',
+  tile3Content: 'Kachel 3',
+  tile4Content: 'Kachel 4',
+  ctaText: 'Mehr erfahren',
+  ctaUrl: '#'
+});
+</script>
+```

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -1,0 +1,98 @@
+:root {
+  --overlay-bg: rgba(0, 0, 0, 0.6);
+  --tile-bg: #fff;
+  --tile-color: #333;
+  --radius: 8px;
+  --shadow: 0 2px 10px rgba(0,0,0,0.2);
+  --gap: 1rem;
+}
+
+.ffo-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--overlay-bg);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 1000;
+}
+
+.ffo-overlay.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.ffo-overlay__inner {
+  position: relative;
+  width: 90%;
+  max-width: 960px;
+  animation: ffo-slide-up 0.4s ease forwards;
+}
+
+.ffo-overlay__title {
+  color: var(--tile-color);
+  text-align: center;
+  margin: 0 0 var(--gap) 0;
+}
+
+.ffo-overlay__grid {
+  display: grid;
+  gap: var(--gap);
+}
+
+@media (max-width: 600px) {
+  .ffo-overlay__grid { grid-template-columns: 1fr; }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .ffo-overlay__grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 901px) {
+  .ffo-overlay__grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.ffo-overlay__tile {
+  background: var(--tile-bg);
+  color: var(--tile-color);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ffo-overlay__tile:hover {
+  transform: scale(1.03);
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+}
+
+.ffo-overlay__cta {
+  display: inline-block;
+  margin-top: var(--gap);
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius);
+  background: var(--tile-color);
+  color: var(--tile-bg);
+  text-decoration: none;
+}
+
+.ffo-overlay__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 2rem;
+  color: var(--tile-bg);
+  line-height: 1;
+  cursor: pointer;
+}
+
+@keyframes ffo-slide-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/assets/overlay.js
+++ b/assets/overlay.js
@@ -1,0 +1,64 @@
+(function(){
+  function showOverlay(params){
+    var opts = Object.assign({
+      overlayTitle: '',
+      tile1Content: '',
+      tile2Content: '',
+      tile3Content: '',
+      tile4Content: '',
+      ctaText: '',
+      ctaUrl: '#'
+    }, params || {});
+
+    var overlay = document.createElement('div');
+    overlay.className = 'ffo-overlay';
+
+    overlay.innerHTML =
+      '<div class="ffo-overlay__inner">' +
+        '<button class="ffo-overlay__close" aria-label="Close Overlay">&times;</button>' +
+        '<h2 class="ffo-overlay__title">' + opts.overlayTitle + '</h2>' +
+        '<div class="ffo-overlay__grid">' +
+          '<div class="ffo-overlay__tile">' + opts.tile1Content + '</div>' +
+          '<div class="ffo-overlay__tile">' + opts.tile2Content + '</div>' +
+          '<div class="ffo-overlay__tile">' + opts.tile3Content + '</div>' +
+          '<div class="ffo-overlay__tile">' + opts.tile4Content + '</div>' +
+        '</div>' +
+        '<a class="ffo-overlay__cta" href="' + opts.ctaUrl + '">' + opts.ctaText + '</a>' +
+      '</div>';
+
+    document.body.appendChild(overlay);
+    // Ensure CSS transition
+    requestAnimationFrame(function(){
+      overlay.classList.add('is-visible');
+    });
+
+    function remove(){
+      overlay.classList.remove('is-visible');
+      overlay.addEventListener('transitionend', function(){
+        overlay.remove();
+      }, { once: true });
+    }
+
+    overlay.querySelector('.ffo-overlay__close').addEventListener('click', remove);
+    overlay.addEventListener('click', function(e){
+      if(e.target === overlay){
+        remove();
+      }
+    });
+  }
+
+  window.showOverlay = showOverlay;
+  window.showOverlayFromElement = function(el){
+    if(!el) return;
+    var d = el.dataset;
+    showOverlay({
+      overlayTitle: d.overlayTitle || '',
+      tile1Content: d.tile1Content || '',
+      tile2Content: d.tile2Content || '',
+      tile3Content: d.tile3Content || '',
+      tile4Content: d.tile4Content || '',
+      ctaText: d.ctaText || '',
+      ctaUrl: d.ctaUrl || '#'
+    });
+  };
+})();

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -103,6 +103,9 @@ function ffo_layout_render_shortcode_column( $column, $post_id ) {
 add_action( 'wp_enqueue_scripts', 'ffo_enqueue_assets' );
 function ffo_enqueue_assets() {
     wp_enqueue_style( 'freeflexoverlay-style', FFO_URL . 'assets/style.css', [], FFO_VERSION );
+    // Overlay component assets
+    wp_enqueue_style( 'ffo-overlay', FFO_URL . 'assets/overlay.css', [], FFO_VERSION );
+    wp_enqueue_script( 'ffo-overlay', FFO_URL . 'assets/overlay.js', [], FFO_VERSION, true );
     // Previously a search script was enqueued here. It has been removed.
 }
 

--- a/templates/overlay-template.html
+++ b/templates/overlay-template.html
@@ -1,0 +1,12 @@
+<!-- Overlay HTML template with data attributes for dynamic content -->
+<div class="ffo-overlay-trigger"
+     data-overlay-title="Ihr Titel hier"
+     data-tile1-content="Inhalt Kachel 1"
+     data-tile2-content="Inhalt Kachel 2"
+     data-tile3-content="Inhalt Kachel 3"
+     data-tile4-content="Inhalt Kachel 4"
+     data-cta-text="Zum Angebot"
+     data-cta-url="https://example.com">
+  <!-- Dieses Element kann als Auslöser dienen -->
+</div>
+<!-- Die Funktion showOverlayFromElement(this) kann verwendet werden, um das Overlay auszulösen. -->


### PR DESCRIPTION
## Summary
- add responsive overlay grid component JS/CSS
- enqueue overlay assets in plugin
- document overlay usage in README
- provide example template for data attributes

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68581cd98c708329ba2bd4d943916cdb