### PR TITLE
Improve fullwidth tile layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2,8 +2,11 @@
 .ffo-fullwidth {
   width: 100%;
   padding: 2rem;
-  background: #f5f5f5;
+  background: #fff;
   margin-bottom: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  min-height: 200px;
 }
 .ffo-grid {
   display: grid;
@@ -26,7 +29,15 @@
 /* Overlay search styles were removed */
 
 /* Layout fullwidth-2x2-fullwidth */
-.pm-fullwidth { width: 100%; padding: 2rem; background: #f5f5f5; margin-bottom: 2rem; }
+.pm-fullwidth {
+  width: 100%;
+  padding: 2rem;
+  background: #fff;
+  margin-bottom: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  min-height: 200px;
+}
 .pm-grid--2x2 {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -39,4 +50,8 @@
   padding: 1.5rem;
   border: 1px solid #ddd;
   border-radius: 8px;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- adjust styling for fullwidth modules
- make grid tiles square and center content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68581e92160c83299e0e15e34634c309