### PR TITLE
Fix overlay tile proportions

### DIFF
--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -44,16 +44,7 @@
 .ffo-overlay__grid {
   display: grid;
   gap: var(--gap);
-}
-
-@media (max-width: 600px) {
-  .ffo-overlay__grid { grid-template-columns: 1fr; }
-}
-@media (min-width: 601px) and (max-width: 900px) {
-  .ffo-overlay__grid { grid-template-columns: repeat(2, 1fr); }
-}
-@media (min-width: 901px) {
-  .ffo-overlay__grid { grid-template-columns: repeat(3, 1fr); }
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
 .ffo-overlay__tile {
@@ -61,6 +52,7 @@
   color: var(--tile-color);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
+  aspect-ratio: 1 / 1;
   padding: 1rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- use auto-fit grid for overlay tiles
- keep tiles square with `aspect-ratio`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68581f8ae1e48329a0ecba8d026f5934