### PR TITLE
Fix spacing between grid and fullwidth tile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -42,7 +42,7 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   grid-auto-rows: 1fr;
 }
 .pm-grid__item {


### PR DESCRIPTION
## Summary
- reduce margin after 2x2 grid so the fullwidth tile sits closer

## Testing
- `npm test` *(fails: could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685820c889048329a2a6b74576f86065