### PR TITLE
Fix excessive spacing after grid

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -38,11 +38,16 @@
   border-radius: 8px;
   min-height: 200px;
 }
+
+.pm-fullwidth--bottom {
+  margin-top: 0;
+}
+
 .pm-grid--2x2 {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
   grid-auto-rows: 1fr;
 }
 .pm-grid__item {


### PR DESCRIPTION
## Summary
- tweak styles so there is no margin after the 2x2 grid
- add specific class for the bottom fullwidth section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68582525734c83298517e9e7a768e202