### PR TITLE
Fix paragraph spacing in page modules

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -60,3 +60,8 @@
   align-items: center;
   justify-content: center;
 }
+
+.pm-grid__item p,
+.pm-fullwidth p {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- reduce default spacing from `<p>` tags in module layouts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68582814872c8329831c440a8b9fd0e5