### PR TITLE
Strip empty paragraphs when shortcode used

### DIFF
--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -199,3 +199,15 @@ function ffo_pm_grid_remove_wpautop( $block_content, $block ) {
 
     return $block_content;
 }
+
+/**
+ * Strip empty <p> tags when our shortcode is present.
+ */
+add_filter( 'the_content', 'ffo_strip_empty_paragraphs', 9 );
+function ffo_strip_empty_paragraphs( $content ) {
+    if ( has_shortcode( $content, 'free_flexio_modules' ) ) {
+        $content = preg_replace( '/<p>\s*<\/p>/', '', $content );
+    }
+
+    return $content;
+}


### PR DESCRIPTION
## Summary
- remove empty `<p>` tags in content when shortcode `[free_flexio_modules]` is present

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582a9d088c8329ba79857b69649a27