### PR TITLE
Fix HTML rendering and grid styles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -13,6 +13,7 @@
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
   grid-auto-rows: 1fr;
+  margin-bottom: 2rem;
 }
 .ffo-grid .ffo-row {
   display: contents;
@@ -24,6 +25,12 @@
   padding: 1.5rem;
   border: 1px solid #ddd;
   border-radius: 8px;
+}
+.ffo-col img,
+.pm-grid__item img {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
 /* Overlay search styles were removed */
@@ -59,6 +66,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 
 .pm-grid__item p,

--- a/templates/layout-fullwidth-2x2-fullwidth.php
+++ b/templates/layout-fullwidth-2x2-fullwidth.php
@@ -1,8 +1,8 @@
 <div class="pm-fullwidth pm-fullwidth--top">
 <?php 
-$top_content = get_post_meta($post->ID, 'ffo_fullwidth_top', true);
-if ( trim(strip_tags($top_content)) !== '' ) {
-    echo apply_filters('the_content', $top_content);
+$top_content = get_post_meta( $post->ID, 'ffo_fullwidth_top', true );
+if ( trim( $top_content ) !== '' ) {
+    echo apply_filters( 'the_content', $top_content );
 }
 ?>
 </div>
@@ -10,9 +10,9 @@ if ( trim(strip_tags($top_content)) !== '' ) {
 <?php for ($i = 1; $i <= 4; $i++) : ?>
     <div class="pm-grid__item">
         <?php 
-        $item = get_post_meta($post->ID, "ffo_grid_item_{$i}", true);
-        if ( trim(strip_tags($item)) !== '' ) {
-            echo apply_filters('the_content', $item);
+        $item = get_post_meta( $post->ID, "ffo_grid_item_{$i}", true );
+        if ( trim( $item ) !== '' ) {
+            echo apply_filters( 'the_content', $item );
         }
         ?>
     </div>
@@ -20,9 +20,9 @@ if ( trim(strip_tags($top_content)) !== '' ) {
 </div>
 <div class="pm-fullwidth pm-fullwidth--bottom">
 <?php 
-$bottom_content = get_post_meta($post->ID, 'ffo_fullwidth_bottom', true);
-if ( trim(strip_tags($bottom_content)) !== '' ) {
-    echo apply_filters('the_content', $bottom_content);
+$bottom_content = get_post_meta( $post->ID, 'ffo_fullwidth_bottom', true );
+if ( trim( $bottom_content ) !== '' ) {
+    echo apply_filters( 'the_content', $bottom_content );
 }
 ?>
 </div>


### PR DESCRIPTION
## Summary
- ensure HTML-only content displays in `fullwidth-2x2-fullwidth` layout
- improve grid and image styling

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685831bd308c832996e6176fbaac5974