### PR TITLE
Style maps to fill modules

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -86,3 +86,14 @@
 .pm-fullwidth--bottom {
   margin-top: 2rem !important;
 }
+
+/* Map iframe styling */
+.ffo-fullwidth iframe,
+.ffo-col iframe,
+.pm-grid__item iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 8px;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- make embedded maps fill the full module container
- round corners of map iframes

## Testing
- `php -l $file` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685835b589808329a2d689f8aa27585d