### PR TITLE
Reduce overlay width

### DIFF
--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -30,7 +30,8 @@
 
 .ffo-overlay__inner {
   position: relative;
-  width: 90%;
+  /* Leave a 10% gap on the left and right by reducing the width */
+  width: 80%;
 /*  max-width: 960px; */
   animation: ffo-slide-up 0.4s ease forwards;
 }


### PR DESCRIPTION
## Summary
- shrink overlay to leave 10% space at the sides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858432b4cb083299e0506392ac15196