### PR TITLE
Fix layout pattern defaults

### DIFF
--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -186,7 +186,7 @@ function ffo_apply_pattern_defaults( $post_id ) {
     }
 
     $defaults = array();
-    if ( 'pattern1' === $pattern ) {
+    if ( in_array( $pattern, array( 'fullwidth-2x2-fullwidth', 'pattern1' ), true ) ) {
         $defaults = array(
             ffo_empty_module( 'fullwidth' ),
             ffo_empty_module( 'grid' ),

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -33,7 +33,7 @@ function ffo_render_modules_shortcode( $atts = array() ) {
         // When no custom modules exist output simple placeholders for the
         // selected pattern. This keeps backward compatibility with older
         // behaviour where the pattern rendered static demo content.
-        if ( $pattern === 'pattern1' ) {
+        if ( in_array( $pattern, array( 'fullwidth-2x2-fullwidth', 'pattern1' ), true ) ) {
             $output .= '<div class="ffo-fullwidth">' . __( 'Standard Fullwidth-Content', 'freeflexoverlay' ) . '</div>';
             $output .= '<div class="ffo-grid"><!-- 4 Items --></div>';
             $output .= '<div class="ffo-fullwidth">' . __( 'Standard Fullwidth-Content', 'freeflexoverlay' ) . '</div>';


### PR DESCRIPTION
## Summary
- make default module insertion compatible with old and new layout names
- update placeholder logic accordingly

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685843f320dc8329b9100a132c14f598