### PR TITLE
Add titles and text for overlay tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ Example:
 <script>
 showOverlay({
   overlayTitle: 'Titel',
-  tile1Content: 'Kachel 1',
-  tile2Content: 'Kachel 2',
-  tile3Content: 'Kachel 3',
-  tile4Content: 'Kachel 4',
+  tile1Title: 'Überschrift 1',
+  tile1Text: 'Kachel 1 Text',
+  tile2Title: 'Überschrift 2',
+  tile2Text: 'Kachel 2 Text',
+  tile3Title: 'Überschrift 3',
+  tile3Text: 'Kachel 3 Text',
+  tile4Title: 'Überschrift 4',
+  tile4Text: 'Kachel 4 Text',
   ctaText: 'Mehr erfahren',
   ctaUrl: '#'
 });

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -63,6 +63,17 @@
   box-shadow: 0 4px 20px rgba(0,0,0,0.3);
 }
 
+.ffo-overlay__tile-title {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.ffo-overlay__tile-text {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
 .ffo-overlay__cta {
   display: inline-block;
   margin-top: var(--gap);

--- a/assets/overlay.js
+++ b/assets/overlay.js
@@ -2,10 +2,14 @@
   function showOverlay(params){
     var opts = Object.assign({
       overlayTitle: '',
-      tile1Content: '',
-      tile2Content: '',
-      tile3Content: '',
-      tile4Content: '',
+      tile1Title: '',
+      tile1Text: '',
+      tile2Title: '',
+      tile2Text: '',
+      tile3Title: '',
+      tile3Text: '',
+      tile4Title: '',
+      tile4Text: '',
       ctaText: '',
       ctaUrl: '#'
     }, params || {});
@@ -18,10 +22,22 @@
         '<button class="ffo-overlay__close" aria-label="Close Overlay">&times;</button>' +
         '<h2 class="ffo-overlay__title">' + opts.overlayTitle + '</h2>' +
         '<div class="ffo-overlay__grid">' +
-          '<div class="ffo-overlay__tile">' + opts.tile1Content + '</div>' +
-          '<div class="ffo-overlay__tile">' + opts.tile2Content + '</div>' +
-          '<div class="ffo-overlay__tile">' + opts.tile3Content + '</div>' +
-          '<div class="ffo-overlay__tile">' + opts.tile4Content + '</div>' +
+          '<div class="ffo-overlay__tile">' +
+            '<h3 class="ffo-overlay__tile-title">' + opts.tile1Title + '</h3>' +
+            '<p class="ffo-overlay__tile-text">' + opts.tile1Text + '</p>' +
+          '</div>' +
+          '<div class="ffo-overlay__tile">' +
+            '<h3 class="ffo-overlay__tile-title">' + opts.tile2Title + '</h3>' +
+            '<p class="ffo-overlay__tile-text">' + opts.tile2Text + '</p>' +
+          '</div>' +
+          '<div class="ffo-overlay__tile">' +
+            '<h3 class="ffo-overlay__tile-title">' + opts.tile3Title + '</h3>' +
+            '<p class="ffo-overlay__tile-text">' + opts.tile3Text + '</p>' +
+          '</div>' +
+          '<div class="ffo-overlay__tile">' +
+            '<h3 class="ffo-overlay__tile-title">' + opts.tile4Title + '</h3>' +
+            '<p class="ffo-overlay__tile-text">' + opts.tile4Text + '</p>' +
+          '</div>' +
         '</div>' +
         '<a class="ffo-overlay__cta" href="' + opts.ctaUrl + '">' + opts.ctaText + '</a>' +
       '</div>';
@@ -53,10 +69,14 @@
     var d = el.dataset;
     showOverlay({
       overlayTitle: d.overlayTitle || '',
-      tile1Content: d.tile1Content || '',
-      tile2Content: d.tile2Content || '',
-      tile3Content: d.tile3Content || '',
-      tile4Content: d.tile4Content || '',
+      tile1Title: d.tile1Title || '',
+      tile1Text: d.tile1Text || '',
+      tile2Title: d.tile2Title || '',
+      tile2Text: d.tile2Text || '',
+      tile3Title: d.tile3Title || '',
+      tile3Text: d.tile3Text || '',
+      tile4Title: d.tile4Title || '',
+      tile4Text: d.tile4Text || '',
       ctaText: d.ctaText || '',
       ctaUrl: d.ctaUrl || '#'
     });

--- a/templates/overlay-template.html
+++ b/templates/overlay-template.html
@@ -1,10 +1,14 @@
 <!-- Overlay HTML template with data attributes for dynamic content -->
 <div class="ffo-overlay-trigger"
      data-overlay-title="Ihr Titel hier"
-     data-tile1-content="Inhalt Kachel 1"
-     data-tile2-content="Inhalt Kachel 2"
-     data-tile3-content="Inhalt Kachel 3"
-     data-tile4-content="Inhalt Kachel 4"
+     data-tile1-title="Überschrift 1"
+     data-tile1-text="Text Kachel 1"
+     data-tile2-title="Überschrift 2"
+     data-tile2-text="Text Kachel 2"
+     data-tile3-title="Überschrift 3"
+     data-tile3-text="Text Kachel 3"
+     data-tile4-title="Überschrift 4"
+     data-tile4-text="Text Kachel 4"
      data-cta-text="Zum Angebot"
      data-cta-url="https://example.com">
   <!-- Dieses Element kann als Auslöser dienen -->


### PR DESCRIPTION
## Summary
- overlay tiles now support a title and text field
- style overlay tile titles and text
- document new parameters in the example
- update template with data attributes for titles and texts

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_68584786d46483298dfaef1eabc1eacf