### PR TITLE
Add grid heading fields to builder

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -91,6 +91,12 @@
   margin-top: 2rem !important;
 }
 
+.ffo-grid-heading {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
 /* Map iframe styling */
 .ffo-fullwidth iframe,
 .ffo-col iframe,

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -217,9 +217,13 @@ function ffo_empty_module( $type ) {
     return array(
         'layout_type'  => $type,
         'full_content' => '',
+        'grid_heading_1' => '',
         'grid_item_1'  => '',
+        'grid_heading_2' => '',
         'grid_item_2'  => '',
+        'grid_heading_3' => '',
         'grid_item_3'  => '',
+        'grid_heading_4' => '',
         'grid_item_4'  => '',
     );
 }

--- a/includes/fallback-meta-boxes.php
+++ b/includes/fallback-meta-boxes.php
@@ -48,6 +48,11 @@ function ffo_render_fallback_metabox( $post ) {
         </p>
         <?php for ( $j = 1; $j <= 4; $j++ ) : ?>
             <p>
+                <label><?php printf( esc_html__( 'Grid Item %d Title', 'freeflexoverlay' ), $j ); ?><br/>
+                    <input type="text" name="ffo_grid_heading_<?php echo $j; ?>" value="<?php echo esc_attr( get_post_meta( $post->ID, $prefix . 'grid_heading_' . $j, true ) ); ?>" style="width:100%;" />
+                </label>
+            </p>
+            <p>
                 <label><?php printf( esc_html__( 'Grid Item %d', 'freeflexoverlay' ), $j ); ?><br/>
                     <textarea name="ffo_grid_item_<?php echo $j; ?>" rows="3" style="width:100%;"><?php echo esc_textarea( get_post_meta( $post->ID, $prefix . 'grid_item_' . $j, true ) ); ?></textarea>
                 </label>
@@ -81,6 +86,11 @@ function ffo_render_single_module( $index, $mod ) {
         </p>
         <?php for ( $j = 1; $j <= 4; $j++ ) : ?>
             <p class="ffo-field-grid">
+                <label><?php printf( esc_html__( 'Grid Item %d Title', 'freeflexoverlay' ), $j ); ?><br/>
+                    <input type="text" name="ffo_modules_group[<?php echo esc_attr( $index ); ?>][grid_heading_<?php echo $j; ?>]" value="<?php echo isset( $mod['grid_heading_' . $j] ) ? esc_attr( $mod['grid_heading_' . $j] ) : ''; ?>" style="width:100%;" />
+                </label>
+            </p>
+            <p class="ffo-field-grid">
                 <label><?php printf( esc_html__( 'Grid Item %d', 'freeflexoverlay' ), $j ); ?><br/>
                     <textarea name="ffo_modules_group[<?php echo esc_attr( $index ); ?>][grid_item_<?php echo $j; ?>]" rows="3" style="width:100%;"><?php echo isset( $mod['grid_item_' . $j] ) ? esc_textarea( $mod['grid_item_' . $j] ) : ''; ?></textarea>
                 </label>
@@ -109,12 +119,16 @@ function ffo_save_fallback_metabox( $post_id ) {
         $modules = [];
         foreach ( $_POST['ffo_modules_group'] as $module ) {
             $modules[] = [
-                'layout_type'  => isset( $module['layout_type'] ) ? sanitize_text_field( $module['layout_type'] ) : '',
-                'full_content' => isset( $module['full_content'] ) ? ffo_kses_post_with_iframe( $module['full_content'] ) : '',
-                'grid_item_1'  => isset( $module['grid_item_1'] ) ? ffo_kses_post_with_iframe( $module['grid_item_1'] ) : '',
-                'grid_item_2'  => isset( $module['grid_item_2'] ) ? ffo_kses_post_with_iframe( $module['grid_item_2'] ) : '',
-                'grid_item_3'  => isset( $module['grid_item_3'] ) ? ffo_kses_post_with_iframe( $module['grid_item_3'] ) : '',
-                'grid_item_4'  => isset( $module['grid_item_4'] ) ? ffo_kses_post_with_iframe( $module['grid_item_4'] ) : '',
+                'layout_type'    => isset( $module['layout_type'] ) ? sanitize_text_field( $module['layout_type'] ) : '',
+                'full_content'   => isset( $module['full_content'] ) ? ffo_kses_post_with_iframe( $module['full_content'] ) : '',
+                'grid_heading_1' => isset( $module['grid_heading_1'] ) ? sanitize_text_field( $module['grid_heading_1'] ) : '',
+                'grid_item_1'    => isset( $module['grid_item_1'] ) ? ffo_kses_post_with_iframe( $module['grid_item_1'] ) : '',
+                'grid_heading_2' => isset( $module['grid_heading_2'] ) ? sanitize_text_field( $module['grid_heading_2'] ) : '',
+                'grid_item_2'    => isset( $module['grid_item_2'] ) ? ffo_kses_post_with_iframe( $module['grid_item_2'] ) : '',
+                'grid_heading_3' => isset( $module['grid_heading_3'] ) ? sanitize_text_field( $module['grid_heading_3'] ) : '',
+                'grid_item_3'    => isset( $module['grid_item_3'] ) ? ffo_kses_post_with_iframe( $module['grid_item_3'] ) : '',
+                'grid_heading_4' => isset( $module['grid_heading_4'] ) ? sanitize_text_field( $module['grid_heading_4'] ) : '',
+                'grid_item_4'    => isset( $module['grid_item_4'] ) ? ffo_kses_post_with_iframe( $module['grid_item_4'] ) : '',
             ];
         }
         update_post_meta( $post_id, $prefix . 'modules_group', $modules );
@@ -123,7 +137,12 @@ function ffo_save_fallback_metabox( $post_id ) {
     }
 
     if ( isset( $_POST['ffo_layout_pattern'] ) && $_POST['ffo_layout_pattern'] === 'fullwidth-2x2-fullwidth' ) {
-        $fields = array( 'fullwidth_top', 'grid_item_1', 'grid_item_2', 'grid_item_3', 'grid_item_4', 'fullwidth_bottom' );
+        $fields = array( 'fullwidth_top',
+            'grid_heading_1', 'grid_item_1',
+            'grid_heading_2', 'grid_item_2',
+            'grid_heading_3', 'grid_item_3',
+            'grid_heading_4', 'grid_item_4',
+            'fullwidth_bottom' );
         foreach ( $fields as $field ) {
             if ( isset( $_POST[ 'ffo_' . $field ] ) ) {
                 update_post_meta( $post_id, $prefix . $field, ffo_kses_post_with_iframe( $_POST[ 'ffo_' . $field ] ) );

--- a/includes/meta-boxes.php
+++ b/includes/meta-boxes.php
@@ -59,6 +59,12 @@ function ffo_register_module_metabox() {
     ) );
     for ( $i = 1; $i <= 4; $i++ ) {
         $cmb->add_group_field( $group_id, array(
+            'name'        => sprintf( __( 'Grid Item %d Title', 'freeflexoverlay' ), $i ),
+            'id'          => 'grid_heading_' . $i,
+            'type'        => 'text',
+            'row_classes' => 'ffo-field-grid',
+        ) );
+        $cmb->add_group_field( $group_id, array(
             'name'        => sprintf( __( 'Grid Item %d', 'freeflexoverlay' ), $i ),
             'id'          => 'grid_item_' . $i,
             'type'        => 'wysiwyg',
@@ -80,6 +86,12 @@ function ffo_register_module_metabox() {
         'sanitization_cb' => 'ffo_kses_post_with_iframe',
     ) );
     for ( $i = 1; $i <= 4; $i++ ) {
+        $cmb->add_field( array(
+            'name'        => sprintf( __( 'Grid Item %d Title', 'freeflexoverlay' ), $i ),
+            'id'          => $prefix . 'grid_heading_' . $i,
+            'type'        => 'text',
+            'row_classes' => 'ffo-fw2x2fw-field',
+        ) );
         $cmb->add_field( array(
             'name'        => sprintf( __( 'Grid Item %d', 'freeflexoverlay' ), $i ),
             'id'          => $prefix . 'grid_item_' . $i,

--- a/includes/render-modules.php
+++ b/includes/render-modules.php
@@ -53,7 +53,11 @@ function ffo_render_modules_shortcode( $atts = array() ) {
                 } elseif ( isset( $mod['layout_type'] ) && $mod['layout_type'] === 'grid' ) {
                     $output .= '<div class="ffo-module ffo-grid"><div class="ffo-row">';
                     for ( $i = 1; $i <= 4; $i++ ) {
-                        $output .= '<div class="ffo-col">' . apply_filters( 'the_content', $mod['grid_item_' . $i] ) . '</div>';
+                        $output .= '<div class="ffo-col">';
+                        if ( ! empty( $mod['grid_heading_' . $i] ) ) {
+                            $output .= '<h3 class="ffo-grid-heading">' . esc_html( $mod['grid_heading_' . $i] ) . '</h3>';
+                        }
+                        $output .= apply_filters( 'the_content', $mod['grid_item_' . $i] ) . '</div>';
                         if ( $i % 2 === 0 && $i < 4 ) {
                             $output .= '</div><div class="ffo-row">';
                         }

--- a/templates/layout-fullwidth-2x2-fullwidth.php
+++ b/templates/layout-fullwidth-2x2-fullwidth.php
@@ -9,7 +9,11 @@ if ( trim( $top_content ) !== '' ) {
 <div class="pm-grid pm-grid--2x2">
 <?php for ($i = 1; $i <= 4; $i++) : ?>
     <div class="pm-grid__item">
-        <?php 
+        <?php
+        $heading = get_post_meta( $post->ID, "ffo_grid_heading_{$i}", true );
+        if ( trim( $heading ) !== '' ) {
+            echo '<h3 class="ffo-grid-heading">' . esc_html( $heading ) . '</h3>';
+        }
         $item = get_post_meta( $post->ID, "ffo_grid_item_{$i}", true );
         if ( trim( $item ) !== '' ) {
             echo apply_filters( 'the_content', $item );


### PR DESCRIPTION
## Summary
- add heading fields to grid modules
- support the new fields in the fallback meta box
- output headings in templates and shortcode renderer
- style grid headings
- update default module structure

## Testing
- `php -l includes/meta-boxes.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685926039fc08329b18d1329362e4de0