### PR TITLE
Fix heading alignment in overlay tiles

### DIFF
--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -63,7 +63,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   text-align: center;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -68,8 +68,9 @@
   min-height: 150px;
   max-height: 300px;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- set tile content to start at the top of each grid item
- place overlay tile headings at the top of the tile

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a8a9be270832986998ef8d9dc312f