### PR TITLE
Fix grid heading alignment

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -96,6 +96,7 @@
   margin-top: 0;
   margin-bottom: 0.5rem;
   font-size: 1.1rem;
+  text-align: center;
 }
 
 /* Map iframe styling */


### PR DESCRIPTION
## Summary
- center text for grid item headings

## Testing
- `php -l freeflexoverlay-builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8d12a21883298bcb728045962e51