### PR TITLE
Allow customizing overlay text sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,9 @@ showOverlay({
 
 The overlay uses several CSS variables that can be overridden to control its
 appearance. In particular the heading sizes can be changed via
-`--overlay-title-size` and `--tile-title-size`.
+`--overlay-title-size` and `--tile-title-size`. The tile text size is
+controlled through `--tile-text-size`.
+
+When calling `showOverlay()` you can also pass `overlayTitleSize`,
+`tileTitleSize` and `tileTextSize` options (or set the corresponding
+`data-*-size` attributes) to set these values for a single overlay.

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -8,6 +8,7 @@
   /* Font sizes can be customised by overriding these variables */
   --overlay-title-size: 1.5rem;
   --tile-title-size: 1.1rem;
+  --tile-text-size: 0.9rem;
 }
 
 .ffo-overlay {
@@ -81,7 +82,7 @@
 
 .ffo-overlay__tile-text {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--tile-text-size);
   text-align: center;
 }
 

--- a/assets/overlay.js
+++ b/assets/overlay.js
@@ -11,11 +11,17 @@
       tile4Title: '',
       tile4Text: '',
       ctaText: '',
-      ctaUrl: '#'
+      ctaUrl: '#',
+      overlayTitleSize: '',
+      tileTitleSize: '',
+      tileTextSize: ''
     }, params || {});
 
     var overlay = document.createElement('div');
     overlay.className = 'ffo-overlay';
+    if(opts.overlayTitleSize) overlay.style.setProperty('--overlay-title-size', opts.overlayTitleSize);
+    if(opts.tileTitleSize) overlay.style.setProperty('--tile-title-size', opts.tileTitleSize);
+    if(opts.tileTextSize) overlay.style.setProperty('--tile-text-size', opts.tileTextSize);
 
     overlay.innerHTML =
       '<div class="ffo-overlay__inner">' +
@@ -78,7 +84,10 @@
       tile4Title: d.tile4Title || '',
       tile4Text: d.tile4Text || '',
       ctaText: d.ctaText || '',
-      ctaUrl: d.ctaUrl || '#'
+      ctaUrl: d.ctaUrl || '#',
+      overlayTitleSize: d.overlayTitleSize || '',
+      tileTitleSize: d.tileTitleSize || '',
+      tileTextSize: d.tileTextSize || ''
     });
   };
 })();

--- a/templates/overlay-template.html
+++ b/templates/overlay-template.html
@@ -10,7 +10,10 @@
      data-tile4-title="Überschrift 4"
      data-tile4-text="Text Kachel 4"
      data-cta-text="Zum Angebot"
-     data-cta-url="https://example.com">
+     data-cta-url="https://example.com"
+     data-overlay-title-size="1.5rem"
+     data-tile-title-size="1.1rem"
+     data-tile-text-size="0.9rem">
   <!-- Dieses Element kann als Auslöser dienen -->
 </div>
 <!-- Die Funktion showOverlayFromElement(this) kann verwendet werden, um das Overlay auszulösen. -->


### PR DESCRIPTION
## Summary
- expose `--tile-text-size` css variable and use it for tile text
- allow specifying overlay/tile heading and text sizes via `showOverlay` options
- support matching data attributes in `showOverlayFromElement`
- update README and template with new options

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685ad5f9619c832987ec31ba65e8d985