### PR TITLE
Fix overlay tile auto height

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,7 @@ When calling `showOverlay()` you can also pass `overlayTitleSize`,
 
 The overlay container automatically adjusts its width for different
 screen sizes. On narrow screens it becomes almost full width while on
-large screens it shrinks a bit for a more balanced appearance. These
-breakpoints can be customised in `assets/overlay.css` if needed.
+large screens it shrinks a bit for a more balanced appearance. The tile
+heights now grow with their content so text is no longer clipped. This
+behaviour and the breakpoints can be customised in `assets/overlay.css`
+if needed.

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -71,7 +71,6 @@
   color: var(--tile-color);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  aspect-ratio: 1 / 1;
   padding: 1rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;


### PR DESCRIPTION
## Summary
- remove fixed aspect ratio from overlay tiles so they expand with content
- document new auto-height behaviour in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ad94197748329bd956f42584e0c82