### PR TITLE
Add dark mode and per-tile heading size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin works best with the CMB2 library. When CMB2 is not present a simplifi
 
 1. Upload the plugin folder to your WordPress installation and activate it.
 2. Install and activate the CMB2 plugin if it isn't already present.
-3. Version 2.6.2 bundles a fallback meta box so the plugin works even without CMB2.
+3. Version 2.7.0 bundles a fallback meta box so the plugin works even without CMB2.
 4. Create a new entry under **Overlay Layouts** and configure modules via the **Page Modules** meta box.
 5. Insert the shortcode `[free_flexio_modules id="123"]` on any page, replacing `123` with the layout ID. Slugs work as well, e.g. `[free_flexio_modules id="startseite"]`.
 
@@ -62,7 +62,9 @@ controlled through `--tile-text-size`.
 
 When calling `showOverlay()` you can also pass `overlayTitleSize`,
 `tileTitleSize` and `tileTextSize` options (or set the corresponding
-`data-*-size` attributes) to set these values for a single overlay.
+`data-*-size` attributes) to set these values for a single overlay. If you need
+different heading sizes for each tile you can additionally pass
+`tile1TitleSize` … `tile4TitleSize` (or `data-tile1-title-size` and so on).
 
 The overlay container automatically adjusts its width for different
 screen sizes. On narrow screens it becomes almost full width while on
@@ -72,3 +74,11 @@ behaviour and the breakpoints can be customised in `assets/overlay.css`
 if needed.
 Font sizes now use CSS `clamp()` to adapt to the viewport and
 iframes keep a 16:9 ratio so content remains readable on any device.
+
+### Dark Mode
+
+The default styles use light colours but the plugin now supports a body
+class `dark-mode`. When that class is present the overlay and module
+elements switch to darker backgrounds and lighter text. If another
+dark‑mode plugin toggles that class the components will adjust
+automatically.

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -11,6 +11,12 @@
   --tile-text-size: clamp(0.85rem, 1.3vw, 0.95rem);
 }
 
+body.dark-mode {
+  --overlay-bg: rgba(0, 0, 0, 0.8);
+  --tile-bg: #2b2b2b;
+  --tile-color: #f1f1f1;
+}
+
 .ffo-overlay {
   position: fixed;
   top: 0;

--- a/assets/overlay.js
+++ b/assets/overlay.js
@@ -14,7 +14,11 @@
       ctaUrl: '#',
       overlayTitleSize: '',
       tileTitleSize: '',
-      tileTextSize: ''
+      tileTextSize: '',
+      tile1TitleSize: '',
+      tile2TitleSize: '',
+      tile3TitleSize: '',
+      tile4TitleSize: ''
     }, params || {});
 
     var overlay = document.createElement('div');
@@ -29,19 +33,27 @@
         '<h2 class="ffo-overlay__title">' + opts.overlayTitle + '</h2>' +
         '<div class="ffo-overlay__grid">' +
           '<div class="ffo-overlay__tile">' +
-            '<h3 class="ffo-overlay__tile-title">' + opts.tile1Title + '</h3>' +
+            '<h3 class="ffo-overlay__tile-title"' +
+              (opts.tile1TitleSize ? ' style="font-size:' + opts.tile1TitleSize + ';"' : '') +
+            '>' + opts.tile1Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile1Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
-            '<h3 class="ffo-overlay__tile-title">' + opts.tile2Title + '</h3>' +
+            '<h3 class="ffo-overlay__tile-title"' +
+              (opts.tile2TitleSize ? ' style="font-size:' + opts.tile2TitleSize + ';"' : '') +
+            '>' + opts.tile2Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile2Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
-            '<h3 class="ffo-overlay__tile-title">' + opts.tile3Title + '</h3>' +
+            '<h3 class="ffo-overlay__tile-title"' +
+              (opts.tile3TitleSize ? ' style="font-size:' + opts.tile3TitleSize + ';"' : '') +
+            '>' + opts.tile3Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile3Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
-            '<h3 class="ffo-overlay__tile-title">' + opts.tile4Title + '</h3>' +
+            '<h3 class="ffo-overlay__tile-title"' +
+              (opts.tile4TitleSize ? ' style="font-size:' + opts.tile4TitleSize + ';"' : '') +
+            '>' + opts.tile4Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile4Text + '</p>' +
           '</div>' +
         '</div>' +
@@ -87,7 +99,11 @@
       ctaUrl: d.ctaUrl || '#',
       overlayTitleSize: d.overlayTitleSize || '',
       tileTitleSize: d.tileTitleSize || '',
-      tileTextSize: d.tileTextSize || ''
+      tileTextSize: d.tileTextSize || '',
+      tile1TitleSize: d.tile1TitleSize || '',
+      tile2TitleSize: d.tile2TitleSize || '',
+      tile3TitleSize: d.tile3TitleSize || '',
+      tile4TitleSize: d.tile4TitleSize || ''
     });
   };
 })();

--- a/assets/style.css
+++ b/assets/style.css
@@ -118,3 +118,12 @@
   border-radius: 8px;
   display: block;
 }
+
+body.dark-mode .ffo-fullwidth,
+body.dark-mode .ffo-col,
+body.dark-mode .pm-fullwidth,
+body.dark-mode .pm-grid__item {
+  background: #333;
+  border-color: #555;
+  color: #eee;
+}

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -3,7 +3,7 @@
 Plugin Name:       wp-overlay-restaurant
 Plugin URI:        https://stb-srv.de/
 Description:       Kombiniert modulare Page-Builder-Module (Fullwidth & 2×2 Grid).
-Version:           2.6.2
+Version:           2.7.0
 Author:            stb-srv
 Author URI:        https://stb-srv.de/
 License:           MIT
@@ -14,7 +14,7 @@ Text Domain:       freeflexoverlay
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'FFO_VERSION', '2.6.2' );
+define( 'FFO_VERSION', '2.7.0' );
 define( 'FFO_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FFO_URL', plugin_dir_url( __FILE__ ) );
 

--- a/templates/overlay-template.html
+++ b/templates/overlay-template.html
@@ -13,7 +13,11 @@
      data-cta-url="https://example.com"
      data-overlay-title-size="1.5rem"
      data-tile-title-size="1.1rem"
-     data-tile-text-size="0.9rem">
+     data-tile-text-size="0.9rem"
+     data-tile1-title-size="1.1rem"
+     data-tile2-title-size="1.1rem"
+     data-tile3-title-size="1.1rem"
+     data-tile4-title-size="1.1rem">
   <!-- Dieses Element kann als Auslöser dienen -->
 </div>
 <!-- Die Funktion showOverlayFromElement(this) kann verwendet werden, um das Overlay auszulösen. -->


### PR DESCRIPTION
## Summary
- allow passing `tile1TitleSize`–`tile4TitleSize` to `showOverlay`
- document new options and dark‑mode behaviour
- support dark mode via `body.dark-mode` in stylesheets
- bump plugin version to 2.7.0

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685adbf840448329a90c6680ad00fc1c