### PR TITLE
Add per-tile title styling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ When calling `showOverlay()` you can also pass `overlayTitleSize`,
 different heading sizes for each tile you can additionally pass
 `tile1TitleSize` … `tile4TitleSize` (or `data-tile1-title-size` and so on).
 
+You can also customise the colour and font for each tile title. Pass
+`tile1TitleColor` … `tile4TitleColor` and `tile1TitleFont` …
+`tile4TitleFont` (or use the corresponding `data-*` attributes) to override the
+default styles individually.
+
 The overlay container automatically adjusts its width for different
 screen sizes. On narrow screens it becomes almost full width while on
 large screens it shrinks a bit for a more balanced appearance. The tile

--- a/assets/overlay.js
+++ b/assets/overlay.js
@@ -18,7 +18,15 @@
       tile1TitleSize: '',
       tile2TitleSize: '',
       tile3TitleSize: '',
-      tile4TitleSize: ''
+      tile4TitleSize: '',
+      tile1TitleColor: '',
+      tile2TitleColor: '',
+      tile3TitleColor: '',
+      tile4TitleColor: '',
+      tile1TitleFont: '',
+      tile2TitleFont: '',
+      tile3TitleFont: '',
+      tile4TitleFont: ''
     }, params || {});
 
     var overlay = document.createElement('div');
@@ -27,6 +35,14 @@
     if(opts.tileTitleSize) overlay.style.setProperty('--tile-title-size', opts.tileTitleSize);
     if(opts.tileTextSize) overlay.style.setProperty('--tile-text-size', opts.tileTextSize);
 
+    function buildStyle(size, color, font){
+      var s = '';
+      if(size) s += 'font-size:' + size + ';';
+      if(color) s += 'color:' + color + ';';
+      if(font) s += 'font-family:' + font + ';';
+      return s ? ' style="' + s + '"' : '';
+    }
+
     overlay.innerHTML =
       '<div class="ffo-overlay__inner">' +
         '<button class="ffo-overlay__close" aria-label="Close Overlay">&times;</button>' +
@@ -34,25 +50,25 @@
         '<div class="ffo-overlay__grid">' +
           '<div class="ffo-overlay__tile">' +
             '<h3 class="ffo-overlay__tile-title"' +
-              (opts.tile1TitleSize ? ' style="font-size:' + opts.tile1TitleSize + ';"' : '') +
+              buildStyle(opts.tile1TitleSize, opts.tile1TitleColor, opts.tile1TitleFont) +
             '>' + opts.tile1Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile1Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
             '<h3 class="ffo-overlay__tile-title"' +
-              (opts.tile2TitleSize ? ' style="font-size:' + opts.tile2TitleSize + ';"' : '') +
+              buildStyle(opts.tile2TitleSize, opts.tile2TitleColor, opts.tile2TitleFont) +
             '>' + opts.tile2Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile2Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
             '<h3 class="ffo-overlay__tile-title"' +
-              (opts.tile3TitleSize ? ' style="font-size:' + opts.tile3TitleSize + ';"' : '') +
+              buildStyle(opts.tile3TitleSize, opts.tile3TitleColor, opts.tile3TitleFont) +
             '>' + opts.tile3Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile3Text + '</p>' +
           '</div>' +
           '<div class="ffo-overlay__tile">' +
             '<h3 class="ffo-overlay__tile-title"' +
-              (opts.tile4TitleSize ? ' style="font-size:' + opts.tile4TitleSize + ';"' : '') +
+              buildStyle(opts.tile4TitleSize, opts.tile4TitleColor, opts.tile4TitleFont) +
             '>' + opts.tile4Title + '</h3>' +
             '<p class="ffo-overlay__tile-text">' + opts.tile4Text + '</p>' +
           '</div>' +
@@ -103,7 +119,15 @@
       tile1TitleSize: d.tile1TitleSize || '',
       tile2TitleSize: d.tile2TitleSize || '',
       tile3TitleSize: d.tile3TitleSize || '',
-      tile4TitleSize: d.tile4TitleSize || ''
+      tile4TitleSize: d.tile4TitleSize || '',
+      tile1TitleColor: d.tile1TitleColor || '',
+      tile2TitleColor: d.tile2TitleColor || '',
+      tile3TitleColor: d.tile3TitleColor || '',
+      tile4TitleColor: d.tile4TitleColor || '',
+      tile1TitleFont: d.tile1TitleFont || '',
+      tile2TitleFont: d.tile2TitleFont || '',
+      tile3TitleFont: d.tile3TitleFont || '',
+      tile4TitleFont: d.tile4TitleFont || ''
     });
   };
 })();

--- a/templates/overlay-template.html
+++ b/templates/overlay-template.html
@@ -12,12 +12,20 @@
      data-cta-text="Zum Angebot"
      data-cta-url="https://example.com"
      data-overlay-title-size="1.5rem"
-     data-tile-title-size="1.1rem"
-     data-tile-text-size="0.9rem"
-     data-tile1-title-size="1.1rem"
-     data-tile2-title-size="1.1rem"
-     data-tile3-title-size="1.1rem"
-     data-tile4-title-size="1.1rem">
+      data-tile-title-size="1.1rem"
+      data-tile-text-size="0.9rem"
+      data-tile1-title-size="1.1rem"
+      data-tile1-title-color="#333"
+      data-tile1-title-font="inherit"
+      data-tile2-title-size="1.1rem"
+      data-tile2-title-color="#333"
+      data-tile2-title-font="inherit"
+      data-tile3-title-size="1.1rem"
+      data-tile3-title-color="#333"
+      data-tile3-title-font="inherit"
+      data-tile4-title-size="1.1rem"
+      data-tile4-title-color="#333"
+      data-tile4-title-font="inherit">
   <!-- Dieses Element kann als Auslöser dienen -->
 </div>
 <!-- Die Funktion showOverlayFromElement(this) kann verwendet werden, um das Overlay auszulösen. -->


### PR DESCRIPTION
## Summary
- support individual title color and font for all grid tiles
- document the new options and data attributes
- update overlay template with example attributes

## Testing
- `node -e "require('./assets/overlay.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685adeacd4848329a37ef8b45fdf6165