### PR TITLE
Improve mobile grid layout

### DIFF
--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -72,6 +72,12 @@ body.dark-mode {
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
+@media (max-width: 600px) {
+  .ffo-overlay__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .ffo-overlay__tile {
   background: var(--tile-bg);
   color: var(--tile-color);

--- a/assets/style.css
+++ b/assets/style.css
@@ -60,6 +60,12 @@
   margin-bottom: 0;
   grid-auto-rows: auto;
 }
+
+@media (max-width: 600px) {
+  .pm-grid--2x2 {
+    grid-template-columns: 1fr;
+  }
+}
 .pm-grid__item {
   background: #fff;
   padding: 1.5rem;


### PR DESCRIPTION
## Summary
- keep 2x2 content readable on phones by collapsing the grid to one column
- make overlay tile grid single column on small screens as well

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ae11a5a9883299f20973c6b76b959