### PR TITLE
Improve dark mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ iframes keep a 16:9 ratio so content remains readable on any device.
 
 ### Dark Mode
 
-The default styles use light colours but the plugin now supports a body
-class `dark-mode`. When that class is present the overlay and module
-elements switch to darker backgrounds and lighter text. If another
-dark‑mode plugin toggles that class the components will adjust
-automatically. The admin interface respects the same class so module
-controls remain usable when a backend dark‑mode plugin is active.
+The default styles use light colours but the plugin supports both a body
+class `dark-mode` and automatic detection via the
+`prefers-color-scheme` media query. When a dark scheme is active the
+overlay and module elements switch to darker backgrounds and lighter
+text. If another dark‑mode plugin toggles the class the components will
+adjust automatically. The admin interface respects the same class and
+media query so module controls remain usable when a backend dark‑mode
+plugin is active.

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -22,3 +22,14 @@ body.dark-mode #ffo-modules .ffo-module {
 body.dark-mode .ffo-remove-module {
   color: #f88;
 }
+
+@media (prefers-color-scheme: dark) {
+  #ffo-modules .ffo-module {
+    background: #2b2b2b;
+    border-color: #555;
+    color: #eee;
+  }
+  .ffo-remove-module {
+    color: #f88;
+  }
+}

--- a/assets/overlay.css
+++ b/assets/overlay.css
@@ -17,6 +17,14 @@ body.dark-mode {
   --tile-color: #f1f1f1;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --overlay-bg: rgba(0, 0, 0, 0.8);
+    --tile-bg: #2b2b2b;
+    --tile-color: #f1f1f1;
+  }
+}
+
 .ffo-overlay {
   position: fixed;
   top: 0;

--- a/assets/style.css
+++ b/assets/style.css
@@ -133,3 +133,14 @@ body.dark-mode .pm-grid__item {
   border-color: #555;
   color: #eee;
 }
+
+@media (prefers-color-scheme: dark) {
+  .ffo-fullwidth,
+  .ffo-col,
+  .pm-fullwidth,
+  .pm-grid__item {
+    background: #333;
+    border-color: #555;
+    color: #eee;
+  }
+}


### PR DESCRIPTION
## Summary
- support automatic dark mode via `prefers-color-scheme`
- mention auto detection in documentation

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae8117e808329aac60a7664916c5c