### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -39,3 +39,22 @@ body.darkmode .ffo-remove-module {
     color: #f88;
   }
 }
+
+/* Darkmode base admin styles */
+body.darkmode {
+  background-color: #111 !important;
+  color: #fff !important;
+}
+
+body.darkmode #ffo-modules .ffo-module {
+  background-color: #222 !important;
+  color: #fff !important;
+}
+
+#darkmode-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 9999;
+}
+

--- a/assets/darkmode.js
+++ b/assets/darkmode.js
@@ -1,0 +1,11 @@
+const toggleDarkMode = () => {
+    document.body.classList.toggle('darkmode');
+    localStorage.setItem('darkmode', document.body.classList.contains('darkmode'));
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (localStorage.getItem('darkmode') === 'true') {
+        document.body.classList.add('darkmode');
+    }
+    document.getElementById('darkmode-toggle')?.addEventListener('click', toggleDarkMode);
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -156,3 +156,25 @@ body.darkmode .pm-grid__item {
     color: #eee;
   }
 }
+
+/* Darkmode toggle base styles */
+body.darkmode {
+  background-color: #111 !important;
+  color: #fff !important;
+}
+
+body.darkmode .ffo-fullwidth,
+body.darkmode .ffo-col,
+body.darkmode .pm-fullwidth,
+body.darkmode .pm-grid__item {
+  background-color: #222 !important;
+  color: #fff !important;
+}
+
+#darkmode-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 9999;
+}
+

--- a/freeflexoverlay-builder.php
+++ b/freeflexoverlay-builder.php
@@ -145,6 +145,8 @@ function ffo_enqueue_assets() {
     // Overlay component assets
     wp_enqueue_style( 'ffo-overlay', FFO_URL . 'assets/overlay.css', [], FFO_VERSION );
     wp_enqueue_script( 'ffo-overlay', FFO_URL . 'assets/overlay.js', [], FFO_VERSION, true );
+    // Darkmode toggle script
+    wp_enqueue_script( 'ffo-darkmode', FFO_URL . 'assets/darkmode.js', [], FFO_VERSION, true );
     // Previously a search script was enqueued here. It has been removed.
 }
 
@@ -153,6 +155,7 @@ function ffo_admin_assets( $hook ) {
     if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
         wp_enqueue_script( 'freeflexoverlay-admin', FFO_URL . 'assets/admin.js', [ 'jquery' ], FFO_VERSION, true );
         wp_enqueue_style( 'freeflexoverlay-admin-style', FFO_URL . 'assets/admin.css', [], FFO_VERSION );
+        wp_enqueue_script( 'ffo-darkmode', FFO_URL . 'assets/darkmode.js', [], FFO_VERSION, true );
     }
 }
 
@@ -261,4 +264,20 @@ function ffo_enqueue_overlay_css() {
     wp_register_style( 'ffo-inline-css', false );
     wp_enqueue_style( 'ffo-inline-css' );
     wp_add_inline_style( 'ffo-inline-css', $css );
+}
+
+add_action( 'wp_footer', 'ffo_darkmode_button' );
+add_action( 'admin_footer', 'ffo_darkmode_button' );
+function ffo_darkmode_button() {
+    echo '<button id="darkmode-toggle" class="ffo-darkmode-toggle">' . esc_html__( 'Darkmode', 'freeflexoverlay' ) . '</button>';
+}
+
+add_action( 'wp_ajax_ajax_toggle_dark', 'ajax_toggle_dark' );
+add_action( 'wp_ajax_nopriv_ajax_toggle_dark', 'ajax_toggle_dark' );
+function ajax_toggle_dark() {
+    $state = isset( $_POST['state'] ) ? sanitize_text_field( wp_unslash( $_POST['state'] ) ) : '';
+    if ( is_user_logged_in() ) {
+        update_user_meta( get_current_user_id(), 'ffo_darkmode', $state );
+    }
+    wp_send_json_success();
 }


### PR DESCRIPTION
## Summary
- add dark mode toggle script
- load dark mode assets for frontend and admin
- output dark mode toggle button
- extend styles for dark mode

## Testing
- `zip -r wp-overlay-restaurant.zip wp-overlay-restaurant -x "wp-overlay-restaurant/.git/*"`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aeb98cab48329897fde33444ee68e